### PR TITLE
Make the Claude Code statusLine sample limit-aware (menu-bar value + icon)

### DIFF
--- a/docs/samples/claude-code/runcat-statusline.py
+++ b/docs/samples/claude-code/runcat-statusline.py
@@ -17,10 +17,12 @@ Writes ~/.claude/runcat-usage.json shaped like:
       "lastUpdatedDate": "2026-06-07T05:55:36Z"
     }
 
-The card icon reflects how close you are to your plan limit: an empty circle
-fills up as the 5h / 7d usage rises, and becomes a warning triangle once you
-are near the cap. RunCat renders the menu-bar icon monochrome, so the level is
-conveyed by SHAPE rather than colour.
+This sample is limit-aware: the menu-bar value shows the 5h session limit %
+(the number that tells you how close you are to being rate-limited), and the
+card icon fills up as the 5h / 7d usage rises, turning into a warning triangle
+near the cap. RunCat renders the menu-bar icon monochrome, so the level is
+conveyed by SHAPE rather than colour. Both fall back gracefully (context % on
+the bar, staroflife icon) when no rate-limit data is present.
 """
 
 import json
@@ -79,8 +81,10 @@ snapshot = {
     ] if m is not None],
     "lastUpdatedDate": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
 }
-if ctx is not None:
-    snapshot["metricsBarValue"] = f"{ctx:g}%"
+# menu-bar value: prefer the 5h session limit; fall back to context %
+bar_value = five if five is not None else ctx
+if bar_value is not None:
+    snapshot["metricsBarValue"] = f"{bar_value:g}%"
 
 OUT.parent.mkdir(parents=True, exist_ok=True)
 fd, tmp = tempfile.mkstemp(prefix=".runcat-", dir=str(OUT.parent))

--- a/docs/samples/claude-code/runcat-statusline.py
+++ b/docs/samples/claude-code/runcat-statusline.py
@@ -6,7 +6,7 @@ Writes ~/.claude/runcat-usage.json shaped like:
 
     {
       "title": "Claude Code",
-      "symbol": "staroflife",
+      "symbol": "circle.lefthalf.filled",
       "metricsBarValue": "67%",
       "metrics": [
         {"title": "Model",   "formattedValue": "Opus 4.7"},
@@ -16,6 +16,11 @@ Writes ~/.claude/runcat-usage.json shaped like:
       ],
       "lastUpdatedDate": "2026-06-07T05:55:36Z"
     }
+
+The card icon reflects how close you are to your plan limit: an empty circle
+fills up as the 5h / 7d usage rises, and becomes a warning triangle once you
+are near the cap. RunCat renders the menu-bar icon monochrome, so the level is
+conveyed by SHAPE rather than colour.
 """
 
 import json
@@ -34,6 +39,19 @@ def pct(title, value):
     return {"title": title, "formattedValue": f"{value:g}%", "normalizedValue": round(value / 100, 4)}
 
 
+def limit_symbol(value):
+    """SF Symbol whose shape reflects how full the plan limit is."""
+    if value is None:
+        return "staroflife"
+    if value >= 85:
+        return "exclamationmark.triangle.fill"
+    if value >= 66:
+        return "circle.fill"
+    if value >= 33:
+        return "circle.lefthalf.filled"
+    return "circle"
+
+
 try:
     payload = json.load(sys.stdin)
     if not isinstance(payload, dict):
@@ -47,9 +65,12 @@ rate_limits = payload.get("rate_limits") or {}
 five = (rate_limits.get("five_hour") or {}).get("used_percentage")
 seven = (rate_limits.get("seven_day") or {}).get("used_percentage")
 
+# icon warns as you approach whichever plan limit is closest to its cap
+limit_level = max([v for v in (five, seven) if v is not None], default=None)
+
 snapshot = {
     "title": "Claude Code",
-    "symbol": "staroflife",
+    "symbol": limit_symbol(limit_level),
     "metrics": [m for m in [
         {"title": "Model", "formattedValue": model},
         pct("Context", ctx),


### PR DESCRIPTION
## Context of Contribution

- [ ] Bug Fix
- [ ] Refactoring
- [x] New Feature
- [ ] Others

## Summary of the Proposal

Make the `docs/samples/claude-code/runcat-statusline.py` sample reflect your Claude **plan usage limit**, using data Claude Code already passes to the statusLine (`rate_limits.five_hour` / `seven_day`). Two related touches:

1. **Menu-bar value** now shows the **5h session limit %** instead of context %, so the glanceable number tells you how close you are to being rate-limited. Falls back to context % when no rate-limit data is present.
2. **Card icon** is picked from `max(5h, 7d)` so it fills up as usage rises and becomes a warning triangle near the cap:

| Usage | Icon |
| --- | --- |
| < 33% | `circle` |
| 33–66% | `circle.lefthalf.filled` |
| 66–85% | `circle.fill` |
| ≥ 85% | `exclamationmark.triangle.fill` |

Falls back to the original `staroflife` when limits are absent, so existing behaviour is preserved for those payloads.

## Reason for the new feature

The sample is about surfacing Claude usage, but the two numbers it can show mean different things: context % is "how full is this conversation", while the 5h/7d limits are "how close am I to being cut off". Putting the limit on the bar, plus an icon that visibly warns near the cap, helps any user on a plan with 5h / weekly limits avoid a surprise rate-limit — a general usability win, not a personal preference. RunCat renders the menu-bar icon monochrome, so shape (not colour) carries the signal.

## Notes

- Pure standard library; no new dependencies.
- No credentials and no network access — it only uses the stdin JSON Claude Code already provides.
- Verified with mock payloads: bar shows the 5h value; icon transitions at the documented thresholds; graceful fallback when limits are missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)