### PR TITLE
Add configurable custom metrics card layouts

### DIFF
--- a/LocalPackage/Sources/DataSource/Entities/CustomMetrics/CustomMetricsSnapshot.swift
+++ b/LocalPackage/Sources/DataSource/Entities/CustomMetrics/CustomMetricsSnapshot.swift
@@ -23,6 +23,7 @@ import Foundation
 public struct CustomMetricsSnapshot: Codable, Sendable, Equatable {
     public var title: String
     public var symbol: String?
+    public var contentLayout: CustomMetricsContentLayout?
     public var metricsBarValue: String?
     public var metrics: [CustomMetric]
     public var lastUpdatedDate: Date
@@ -30,14 +31,21 @@ public struct CustomMetricsSnapshot: Codable, Sendable, Equatable {
     public init(
         title: String,
         symbol: String? = nil,
+        contentLayout: CustomMetricsContentLayout? = nil,
         metricsBarValue: String? = nil,
         metrics: [CustomMetric] = [],
         lastUpdatedDate: Date
     ) {
         self.title = title
         self.symbol = symbol
+        self.contentLayout = contentLayout
         self.metricsBarValue = metricsBarValue
         self.metrics = metrics
         self.lastUpdatedDate = lastUpdatedDate
     }
+}
+
+public enum CustomMetricsContentLayout: String, Codable, Sendable, Equatable {
+    case compact
+    case indented
 }

--- a/LocalPackage/Sources/UserInterface/Views/RunnerBar/Dashboard/CustomMetricsCardView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/RunnerBar/Dashboard/CustomMetricsCardView.swift
@@ -38,27 +38,28 @@ struct CustomMetricsCardView: View {
         }
     }
 
+    private var contentLayout: CustomMetricsContentLayout {
+        snapshot.contentLayout ?? .indented
+    }
+
     var body: some View {
-        HStack(alignment: .center, spacing: 16) {
-            Image(systemName: snapshot.displaySymbol)
-                .resizable()
-                .scaledToFit()
-                .frame(width: 24, height: 24)
-            VStack(alignment: .leading, spacing: 2) {
-                Text(verbatim: snapshot.title)
-                Group {
-                    ForEach(snapshot.metrics.enumerated(), id: \.offset) { _, metric in
-                        Text(verbatim: "\(metric.title): \(metric.formattedValue)")
-                            .font(.caption)
-                        if let normalizedValue = metric.normalizedValue {
-                            BarGraphView(value: max(0, min(1, normalizedValue)) * 100)
-                        }
+        Group {
+            if contentLayout == .compact {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(alignment: .center, spacing: 12) {
+                        icon
+                        Text(verbatim: snapshot.title)
                     }
-                    Text("lastUpdated:\(lastUpdatedDetail)", bundle: .module)
-                        .font(.caption)
-                        .foregroundStyle(isFailed ? Color.red : Color.secondary)
+                    details(indented: false)
                 }
-                .padding(.leading, 12)
+            } else {
+                HStack(alignment: .top, spacing: 12) {
+                    icon
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(verbatim: snapshot.title)
+                        details(indented: true)
+                    }
+                }
             }
         }
         .fixedSize()
@@ -66,5 +67,29 @@ struct CustomMetricsCardView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(8)
         .materialCellStyle()
+    }
+
+    private var icon: some View {
+        Image(systemName: snapshot.displaySymbol)
+            .resizable()
+            .scaledToFit()
+            .frame(width: 24, height: 24)
+            .accessibilityHidden(true)
+    }
+
+    private func details(indented: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            ForEach(snapshot.metrics.enumerated(), id: \.offset) { _, metric in
+                Text(verbatim: "\(metric.title): \(metric.formattedValue)")
+                    .font(.caption)
+                if let normalizedValue = metric.normalizedValue {
+                    BarGraphView(value: max(0, min(1, normalizedValue)) * 100)
+                }
+            }
+            Text("lastUpdated:\(lastUpdatedDetail)", bundle: .module)
+                .font(.caption)
+                .foregroundStyle(isFailed ? Color.red : Color.secondary)
+        }
+        .padding(.leading, indented ? 8 : 0)
     }
 }

--- a/LocalPackage/Tests/DataSourceTests/EntityTests/CustomMetricsSnapshotTests.swift
+++ b/LocalPackage/Tests/DataSourceTests/EntityTests/CustomMetricsSnapshotTests.swift
@@ -73,6 +73,25 @@ struct CustomMetricsSnapshotTests {
     }
 
     @Test
+    func decode_snapshot_with_contentLayout() throws {
+        let json = """
+            {
+              "title": "Sessions",
+              "contentLayout": "compact",
+              "metrics": [],
+              "lastUpdatedDate": "2026-06-05T04:50:40Z"
+            }
+            """.data(using: .utf8)!
+        #expect(
+            try decoder.decode(CustomMetricsSnapshot.self, from: json) == CustomMetricsSnapshot(
+                title: "Sessions",
+                contentLayout: .compact,
+                lastUpdatedDate: try #require(ISO8601DateFormatter().date(from: "2026-06-05T04:50:40Z"))
+            )
+        )
+    }
+
+    @Test
     func decode_throws_when_title_missing() {
         let json = """
             {

--- a/docs/CustomMetricsSchema.md
+++ b/docs/CustomMetricsSchema.md
@@ -18,6 +18,7 @@ A valid file might look like this:
 {
   "title": "Claude Code",
   "symbol": "staroflife",
+  "contentLayout": "compact",
   "metricsBarValue": "5.4%",
   "metrics": [
     { "title": "Model",   "formattedValue": "Opus 4.7" },
@@ -37,6 +38,7 @@ The values above are illustrative — `title`, `symbol`, and the metric labels a
 |-------------------|----------------|----------|-------------|
 | `title`           | string         | yes      | Card header text. |
 | `symbol`          | string         | no       | [SF Symbol](https://developer.apple.com/sf-symbols/) identifier shown next to the title. Defaults to `chart.bar.horizontal.page.fill`. |
+| `contentLayout`   | string         | no       | Card body layout: `compact` uses the space below the icon; `indented` aligns all rows to the right of the icon. Defaults to `indented` to preserve the original behavior. |
 | `metricsBarValue` | string         | no       | Short text shown in the Metrics Bar (the dedicated menu-bar item) next to the source's symbol. Displayed verbatim; keep it short — the bar caps the label width and truncates longer strings. Each source is hidden in the bar by default: click the Metrics Bar and flip the source's toggle to show it. When the source is shown but this field is omitted, the bar renders `---`. |
 | `metrics`         | array<Metric\> | yes      | Rows displayed inside the card. Empty array is allowed. |
 | `lastUpdatedDate` | string         | yes      | ISO 8601 timestamp (e.g. `"2026-06-05T04:50:40Z"`) of when the producer wrote this file. Shown as a relative time (`"3 min ago"`) at the bottom of the card; updates automatically. |


### PR DESCRIPTION
## Context of Contribution

- [ ] Bug Fix
- [ ] Refactoring
- [x] New Feature
- [ ] Others

## Summary of the Proposal

This pull request adds an optional `contentLayout` field to Custom Metrics snapshots.

Two layouts are available:

- `indented` keeps the card body to the right of the icon.
- `compact` allows the card body to use the space below the icon.

The default is `indented`, which preserves the existing layout for snapshots that do not specify the field.

All 136 tests pass.

## Reason for the new feature

Cards with several rows or longer values can use the available horizontal space more effectively when their body is allowed to extend below the icon.

The compact layout is useful for dense metrics, while the indented layout remains available for the existing visual structure.

The maintenance cost is limited to one optional enum and two small SwiftUI layout variants. Existing JSON files do not require migration.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) and agree to follow it.
- [x] This PR does not contain commits of multiple contexts.
- [x] Code follows proper indentation and naming conventions.
- [x] Implemented using only APIs that can be submitted to the App Store.