### PR TITLE
Add Claude Code usage-limit docs and out-of-band poller sample

### DIFF
--- a/docs/samples/claude-code/README.md
+++ b/docs/samples/claude-code/README.md
@@ -33,6 +33,10 @@ The output JSON shape is documented in [`../../CustomMetricsSchema.md`](../../Cu
 
 `RUNCAT_OUT_FILE` overrides where the snapshot is written (default: `~/.claude/runcat-usage.json`).
 
+## Usage limits & out-of-band updates
+
+The card refreshes only while Claude Code is running. For reset countdowns, what the statusLine can and can't tell you about your 5h/7d subscription limits, and an **unofficial, experimental** way to update the card without a Claude Code session, see [`USAGE-OUT-OF-BAND.md`](USAGE-OUT-OF-BAND.md).
+
 ## Troubleshooting
 
 - Card shows nothing → confirm Claude Code is calling the statusLine. Run the script by hand to see what it writes:

--- a/docs/samples/claude-code/USAGE-OUT-OF-BAND.md
+++ b/docs/samples/claude-code/USAGE-OUT-OF-BAND.md
@@ -1,0 +1,203 @@
+# Claude usage limits & out-of-band updates
+
+The [statusLine sample](runcat-statusline.py) refreshes the card **only while Claude Code is
+running** — the status line command fires on Claude Code's turns, so when Claude Code is closed
+the card freezes at its last value. This note covers (1) what the statusLine can tell you about
+your subscription rate limits, (2) a supported way to show reset countdowns, and (3) an
+**unofficial, unsupported** way to update the card without a Claude Code session.
+
+## The rate-limit fields
+
+For Claude.ai **Pro/Max** subscribers, Claude Code's statusLine JSON includes rolling usage
+windows. They're absent for API-key / Console usage, and only populate after the first API
+response in a session:
+
+```jsonc
+{
+  "rate_limits": {
+    "five_hour": { "used_percentage": 41, "resets_at": 1784150400 },  // 5-hour window
+    "seven_day": { "used_percentage": 29, "resets_at": 1784606400 }   //  7-day window
+  }
+}
+```
+
+`used_percentage` is 0–100; `resets_at` is Unix epoch seconds. These are the subscription's
+*account-wide* limits (shared across claude.ai, the desktop app, and Claude Code) — but the
+statusLine only surfaces them **to Claude Code, during a session**.
+
+## Supported: reset countdowns
+
+The stock sample shows `5h: 41%`. `resets_at` lets you also show *when* the window clears —
+often the more actionable number. Drop-in replacement for the `pct()` helper:
+
+```python
+from datetime import datetime, timezone
+
+def limit_row(title, node):
+    node = node or {}
+    used = node.get("used_percentage")
+    if used is None:
+        return None
+    text = f"{used:g}%"
+    resets_at = node.get("resets_at")
+    if resets_at:
+        secs = int(resets_at - datetime.now(timezone.utc).timestamp())
+        if secs > 0:
+            h, m = divmod(secs // 60, 60)
+            text += f" · resets {h}h{m:02d}m" if h else f" · resets {m}m"
+    return {"title": title, "formattedValue": text, "normalizedValue": round(used / 100, 4)}
+
+# rate_limits = payload.get("rate_limits") or {}
+# limit_row("5h", rate_limits.get("five_hour"))
+#   ->  {"title": "5h", "formattedValue": "41% · resets 2h11m", "normalizedValue": 0.41}
+```
+
+## Can the card update without Claude Code running?
+
+**Not through any supported API.** If you want the card to reflect your subscription usage while
+Claude Code is closed, know up front that there is no sanctioned path (verified against the
+public docs, 2026-07):
+
+- The `anthropic-ratelimit-*` / `x-ratelimit-*` **response headers** on `/v1/messages` describe
+  **API-key** limits (RPM/TPM) — a separate bucket from the Claude.ai subscription's 5h/7d windows.
+- The **Admin usage/cost API** (`/v1/organizations/usage_report/messages`,
+  `/v1/organizations/cost_report`) is scoped to **API-key organizations**, needs an admin key, and
+  reports API token usage/cost — not consumer subscription limits.
+- No documented endpoint returns a consumer Pro/Max subscription's 5h/7d usage, and nothing
+  persists it to a local file between sessions.
+
+So the supported answer is: the card is a **Claude-Code-session gauge**. RunCat's "Last updated"
+footer already signals when it has gone stale.
+
+## ⚠️ Unofficial / Experimental: out-of-band poller
+
+> **This is not a supported integration.** It calls an **undocumented internal endpoint** that
+> Claude Code uses for its `/usage` command, authenticating with the OAuth token Claude Code
+> stores in your macOS login Keychain. It will break without warning if Anthropic changes the
+> endpoint or the token storage, and automated calls to a non-public endpoint may run against
+> Anthropic's terms of service. Use at your own risk, and please don't open RunCat issues when it
+> breaks — start by re-reading this section.
+
+[`runcat-usage-poll.py`](runcat-usage-poll.py) fetches your 5h / 7d (and, if present, per-model
+weekly) runway from:
+
+```
+GET https://api.anthropic.com/api/oauth/usage
+Authorization: Bearer <token from Keychain item "Claude Code-credentials">
+anthropic-beta: oauth-2025-04-20
+```
+
+…and writes the same `~/.claude/runcat-usage.json` card — **with no Claude Code session running**.
+Drive it on a schedule with launchd ([`com.example.runcat-usage-poll.plist`](com.example.runcat-usage-poll.plist)).
+
+### Setup
+
+1. `cp runcat-usage-poll.py ~/.claude/ && chmod +x ~/.claude/runcat-usage-poll.py`
+2. Run it once by hand: `python3 ~/.claude/runcat-usage-poll.py`. macOS prompts for Keychain access
+   to `Claude Code-credentials` → **Always Allow** (so the scheduled job can read it later). On
+   success it prints the card values.
+   - `--debug` also saves the raw response to `~/.claude/runcat-usage-raw.json` (useful if the
+     endpoint's shape ever changes).
+   - `--selftest` checks the parser with no network and no Keychain access.
+3. Edit `com.example.runcat-usage-poll.plist` (set your real `/Users/YOU/` paths), copy it to
+   `~/Library/LaunchAgents/`, then
+   `launchctl load -w ~/Library/LaunchAgents/com.example.runcat-usage-poll.plist`. Default interval
+   is 10 minutes. Stop it with `launchctl unload …`.
+
+### Known limits
+
+- **Unlocked Mac only.** A launchd agent can read the login Keychain only while your session is
+  unlocked. Asleep / locked / logged-out → no update.
+- **Token expiry when idle.** Claude Code refreshes the stored token when you use it. Go long
+  enough without running Claude Code and the poller gets `401` until you open it again. The script
+  notes where to add a token-refresh flow if you want true independence.
+- **Undocumented.** If the card stops updating, run with `--debug` and check whether the endpoint
+  or response shape changed.
+
+## Payload reference — build any card row you want
+
+`/api/oauth/usage` returns far more than 5h/7d. Every field below can become a card row. Run
+`runcat-usage-poll.py --debug` to see exactly which are populated on your plan — many are
+plan-specific and arrive as `null`. Shapes are undocumented and may change.
+
+### Rolling usage windows (top-level keys)
+
+Each is either `null` or `{"utilization": 0-100, "resets_at": "<ISO-8601>", "limit_dollars": …,
+"used_dollars": …, "remaining_dollars": …}`. The `*_dollars` fields populate only on
+money-metered windows; percentage plans leave them `null`.
+
+| Key | Window |
+|---|---|
+| `five_hour` | 5-hour session window |
+| `seven_day` | 7-day, all models |
+| `seven_day_opus` | 7-day, Opus only |
+| `seven_day_sonnet` | 7-day, Sonnet only |
+| `seven_day_oauth_apps` | 7-day, third-party OAuth-app usage |
+| `seven_day_cowork` | 7-day, Cowork surface |
+
+The response also carries several additional, usually-`null` experimental windows (internal
+code-names) — ignore them unless they show up populated.
+
+### `limits[]` — normalized list (easiest to iterate)
+
+An array of every active limit, already flattened. Iterate this to build rows generically instead
+of reaching for the top-level keys one by one.
+
+| Field | Meaning |
+|---|---|
+| `kind` | `session` \| `weekly_all` \| `weekly_scoped` |
+| `group` | `session` \| `weekly` |
+| `percent` | 0-100 used |
+| `severity` | `normal`, and elevated values as you approach the cap — map to a warning color |
+| `resets_at` | ISO-8601 reset time |
+| `scope` | `null`, or `{"model": {"display_name": "Fable"}, "surface": …}` for `weekly_scoped` |
+| `is_active` | whether this is the currently-binding limit |
+
+### `extra_usage` — pay-as-you-go credits
+
+| Field | Meaning |
+|---|---|
+| `is_enabled` | credits turned on |
+| `utilization` | 0-100 of the credit budget used |
+| `used_credits` / `monthly_limit` | minor units — divide by `10 ** decimal_places` |
+| `currency` / `decimal_places` | e.g. `"EUR"`, `2` → `2691` means `26.91` |
+| `disabled_reason` / `daily` / `weekly` | usually `null` |
+
+### `spend` — the same credits as money (richer)
+
+| Field | Meaning |
+|---|---|
+| `used` / `limit` / `cap.money` | `{"amount_minor", "currency", "exponent"}` — divide `amount_minor` by `10 ** exponent` |
+| `percent` / `severity` | 0-100 and alert level |
+| `enabled` / `disabled_reason` | credit state |
+| `can_purchase_credits` / `can_toggle` | UI capability flags |
+| `disclaimer` | Markdown blurb |
+| `balance` / `auto_reload` | usually `null` |
+
+### `member_dashboard_available`
+
+Boolean — whether a team/member usage dashboard is available.
+
+### Turning a field into a row
+
+RunCat rows are `{"title", "formattedValue", "normalizedValue"}`, where `normalizedValue` (0–1)
+drives the gauge. The poller's `_row()` / `find_window()` helpers make each of these one line:
+
+```python
+# one row per entry in limits[], with per-model scope folded into the title
+for lim in data.get("limits") or []:
+    model = ((lim.get("scope") or {}).get("model") or {}).get("display_name")
+    title = f"{lim['kind']} {model}".strip() if model else lim["kind"]
+    rows.append(_row(title, lim.get("percent"), lim.get("resets_at"), now))
+
+# credits as money, e.g. "26.91 / 150.00 EUR"
+spend = data.get("spend") or {}
+if spend.get("enabled"):
+    used = spend["used"]["amount_minor"] / 10 ** spend["used"]["exponent"]
+    cap = spend["limit"]["amount_minor"] / 10 ** spend["limit"]["exponent"]
+    rows.append({
+        "title": "Credits",
+        "formattedValue": f"{used:.2f} / {cap:.2f} {spend['used']['currency']}",
+        "normalizedValue": round(spend.get("percent", 0) / 100, 4),
+    })
+```

--- a/docs/samples/claude-code/com.example.runcat-usage-poll.plist
+++ b/docs/samples/claude-code/com.example.runcat-usage-poll.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Sample launchd agent for runcat-usage-poll.py (UNOFFICIAL — see USAGE-OUT-OF-BAND.md).
+  Replace /Users/YOU with your home path, then:
+    cp com.example.runcat-usage-poll.plist ~/Library/LaunchAgents/
+    launchctl load -w ~/Library/LaunchAgents/com.example.runcat-usage-poll.plist
+  Runs every 10 minutes while your Mac is unlocked. Stop with `launchctl unload …`.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.example.runcat-usage-poll</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/python3</string>
+    <string>/Users/YOU/.claude/runcat-usage-poll.py</string>
+  </array>
+  <key>StartInterval</key>
+  <integer>600</integer>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>/Users/YOU/.claude/runcat-usage-poll.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/YOU/.claude/runcat-usage-poll.log</string>
+</dict>
+</plist>

--- a/docs/samples/claude-code/runcat-usage-poll.py
+++ b/docs/samples/claude-code/runcat-usage-poll.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""
+RunCat Neo — out-of-band Claude usage poller (UNOFFICIAL / EXPERIMENTAL).
+
+Fetches subscription rate-limit runway from Claude Code's own (undocumented)
+usage endpoint and writes the RunCat Custom Metrics card WITHOUT a running
+Claude Code session:
+
+    GET https://api.anthropic.com/api/oauth/usage
+    Authorization: Bearer <token from login Keychain "Claude Code-credentials">
+    anthropic-beta: oauth-2025-04-20
+
+Response shape (observed):
+    {"five_hour": {"utilization": <0-100>, "resets_at": "<ISO-8601>"},
+     "seven_day": {"utilization": ..., "resets_at": ...},
+     "limits": [{"kind": "weekly_scoped", "percent": ..., "resets_at": ...,
+                 "scope": {"model": {"display_name": "..."}}}, ...], ...}
+
+⚠️  This is NOT a supported integration. The endpoint is undocumented (it backs
+Claude Code's `/usage` command) and can change or vanish on any Claude Code
+update; automated calls to a non-public endpoint may run against Anthropic's
+terms of service. The token is read from the Keychain at runtime and is never
+logged or printed. Use at your own risk. See USAGE-OUT-OF-BAND.md.
+
+  runcat-usage-poll.py                fetch + write the card
+  runcat-usage-poll.py --debug        also dump the raw response to runcat-usage-raw.json
+  runcat-usage-poll.py --from PATH    build from a saved JSON file (no network / no keychain)
+  runcat-usage-poll.py --selftest     check the parsing logic
+
+CUSTOMIZING THE CARD: edit build() below — it's the single place rows, title, SF Symbol, and
+the menu-bar value are assembled. The payload carries far more than 5h/7d (per-model weekly
+caps, pay-as-you-go credits, money spend); every field and a copy-paste recipe are in
+USAGE-OUT-OF-BAND.md -> "Payload reference — build any card row you want".
+
+# No token refresh: on 401 the poller skips the update and waits for Claude Code
+# to refresh the Keychain token next time you use it. If idle-expiry bites, add
+# a refresh: POST https://platform.claude.com/v1/oauth/token with
+# grant_type=refresh_token & client_id=9d1c250a-e61b-44d9-88ed-5944d1962f5e
+# (Claude Code's public OAuth client id).
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+# These three are the usual things to tweak if you're adapting the poller.
+OUT = Path(os.environ.get("RUNCAT_OUT_FILE", str(Path.home() / ".claude" / "runcat-usage.json")))
+RAW = OUT.with_name("runcat-usage-raw.json")  # where --debug dumps the raw response
+KEYCHAIN_ITEM = "Claude Code-credentials"     # login-Keychain item Claude Code stores its token in
+USAGE_URL = "https://api.anthropic.com/api/oauth/usage"
+
+
+def read_token():
+    """OAuth access token from the login Keychain. Returned to the caller, never printed."""
+    raw = subprocess.run(
+        ["security", "find-generic-password", "-s", KEYCHAIN_ITEM, "-w"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    oauth = json.loads(raw)
+    oauth = oauth.get("claudeAiOauth", oauth)  # Claude Code nests creds under this key
+    tok = oauth.get("accessToken") or oauth.get("access_token")
+    if not tok:
+        raise SystemExit("keychain item has no access token")
+    return tok
+
+
+def fetch_usage(token):
+    req = urllib.request.Request(USAGE_URL, headers={
+        "Authorization": f"Bearer {token}",
+        "anthropic-beta": "oauth-2025-04-20",
+        "anthropic-version": "2023-06-01",
+        "User-Agent": "runcat-usage-poll/1",
+    })
+    with urllib.request.urlopen(req, timeout=15) as r:
+        return json.load(r)
+
+
+def _to_epoch(resets_at):
+    """Accept an ISO-8601 string or a unix-epoch number; return epoch seconds or None."""
+    if isinstance(resets_at, (int, float)):
+        return float(resets_at)
+    if isinstance(resets_at, str):
+        try:
+            return datetime.fromisoformat(resets_at).timestamp()
+        except ValueError:
+            return None
+    return None
+
+
+def fmt_reset(resets_at, now):
+    """Human 'resets 2h11m' / 'resets 5d3h' / 'resets now' from a reset time, or None."""
+    epoch = _to_epoch(resets_at)
+    if epoch is None:
+        return None
+    secs = int(epoch - now)
+    if secs <= 0:
+        return "resets now"
+    mins, _ = divmod(secs, 60)
+    hrs, mins = divmod(mins, 60)
+    days, hrs = divmod(hrs, 24)
+    if days:
+        return f"resets {days}d{hrs}h"
+    if hrs:
+        return f"resets {hrs}h{mins:02d}m"
+    return f"resets {mins}m"
+
+
+def _row(title, pct, resets_at, now):
+    """Build one RunCat card row from a 0-100 percentage.
+
+    A row is {"title", "formattedValue", "normalizedValue"}; normalizedValue (0-1) drives the
+    gauge fill/color. Returns None if `pct` isn't a number. Reuse this for any payload field
+    (see USAGE-OUT-OF-BAND.md for the full field list).
+    """
+    if not isinstance(pct, (int, float)):
+        return None
+    reset = fmt_reset(resets_at, now)
+    text = f"{pct:g}%" + (f" · {reset}" if reset else "")
+    return {"title": title, "formattedValue": text, "normalizedValue": round(pct / 100, 4)}
+
+
+def find_window(node, name):
+    """Recursively locate a dict carrying a utilization figure under a key containing `name`
+    (e.g. name="five_hour" / "seven_day" / "seven_day_opus")."""
+    if isinstance(node, dict):
+        for k, v in node.items():
+            if name in k and isinstance(v, dict) and ("utilization" in v or "used_percentage" in v):
+                return v
+        for v in node.values():
+            hit = find_window(v, name)
+            if hit:
+                return hit
+    elif isinstance(node, list):
+        for v in node:
+            hit = find_window(v, name)
+            if hit:
+                return hit
+    return None
+
+
+def window_row(title, window, now):
+    """Row for a top-level rolling window (five_hour, seven_day, seven_day_opus, …)."""
+    if not window:
+        return None
+    pct = window.get("utilization")
+    if pct is None:
+        pct = window.get("used_percentage")
+    return _row(title, pct, window.get("resets_at"), now)
+
+
+def scoped_row(data, now):
+    """The per-model weekly cap, if the response carries one (limits[].kind == weekly_scoped)."""
+    for lim in (data.get("limits") or []):
+        if isinstance(lim, dict) and lim.get("kind") == "weekly_scoped":
+            model = ((lim.get("scope") or {}).get("model") or {}).get("display_name")
+            return _row(f"7d {model}" if model else "7d model", lim.get("percent"), lim.get("resets_at"), now)
+    return None
+
+
+def build(data, now):
+    """Assemble the RunCat card from the usage payload — EDIT HERE to customize the card.
+
+    Returns the snapshot dict, or None if nothing is parseable (the caller then leaves the
+    existing card untouched instead of blanking it).
+
+    Card knobs:
+      metrics         - the rows; each is {"title", "formattedValue", "normalizedValue"} and
+                        normalizedValue (0-1) drives the gauge fill/color
+      title           - card heading
+      symbol          - any SF Symbol name, e.g. "gauge.medium", "bolt.fill"
+      metricsBarValue - the single value shown in the collapsed menu bar
+
+    Add rows with the _row() / find_window() helpers. The payload holds far more than the three
+    windows below (per-model weekly caps, credits, money spend) — see USAGE-OUT-OF-BAND.md ->
+    "Payload reference" for every field and a copy-paste recipe.
+    """
+    # Choose which windows to show — add, remove, or reorder these rows to taste.
+    five = window_row("5h", find_window(data, "five_hour"), now)
+    seven = window_row("7d", find_window(data, "seven_day"), now)
+    scoped = scoped_row(data, now)          # per-model weekly cap (e.g. "7d Fable"), if the plan has one
+    rows = [r for r in [five, seven, scoped] if r]
+    # e.g. to add credits, build a row from data["spend"] here — recipe in USAGE-OUT-OF-BAND.md
+    if not rows:
+        return None
+    snap = {
+        "title": "Claude Code",             # card heading
+        "symbol": "gauge.medium",           # SF Symbol name — swap to taste
+        "metrics": rows,
+        "lastUpdatedDate": datetime.fromtimestamp(now, timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    if five:
+        # value shown in the collapsed menu bar (strip the reset-countdown suffix)
+        snap["metricsBarValue"] = five["formattedValue"].split(" · ")[0]
+    return snap
+
+
+def write_atomic(snap):
+    """Write the card to OUT atomically (temp file + rename) so RunCat never reads a half-written file."""
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=".runcat-", dir=str(OUT.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(snap, f, ensure_ascii=False)
+        os.replace(tmp, OUT)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def selftest():
+    now = datetime(2026, 7, 15, 15, 33, 0, tzinfo=timezone.utc).timestamp()  # 4h37m before the 5h reset
+    data = {
+        "five_hour": {"utilization": 41.0, "resets_at": "2026-07-15T20:10:00.261036+00:00"},
+        "seven_day": {"utilization": 29.0, "resets_at": "2026-07-20T19:00:00+00:00"},
+        "seven_day_opus": None,  # null siblings must be ignored
+        "limits": [
+            {"kind": "session", "percent": 41, "resets_at": "2026-07-15T20:10:00+00:00"},
+            {"kind": "weekly_scoped", "percent": 40, "resets_at": "2026-07-20T19:00:00+00:00",
+             "scope": {"model": {"display_name": "Fable"}}},
+        ],
+    }
+    snap = build(data, now)
+    assert [m["title"] for m in snap["metrics"]] == ["5h", "7d", "7d Fable"], snap
+    assert snap["metrics"][0]["formattedValue"] == "41% · resets 4h37m", snap["metrics"][0]
+    assert snap["metrics"][0]["normalizedValue"] == 0.41
+    assert snap["metrics"][2]["formattedValue"] == "40% · resets 5d3h", snap["metrics"][2]
+    assert snap["metricsBarValue"] == "41%", snap.get("metricsBarValue")
+
+    assert fmt_reset(now + 45 * 60, now) == "resets 45m"          # numeric epoch still works
+    assert fmt_reset("2026-07-15T15:00:00+00:00", now) == "resets now"  # ISO in the past
+    assert build({"unrelated": 1}, now) is None                  # nothing parseable -> None
+    print("selftest ok")
+
+
+def main():
+    if "--selftest" in sys.argv:
+        selftest()
+        return
+    now = datetime.now(timezone.utc).timestamp()
+
+    src = None
+    if "--from" in sys.argv:
+        src = sys.argv[sys.argv.index("--from") + 1]
+
+    if src:
+        data = json.loads(Path(src).read_text())
+    else:
+        try:
+            data = fetch_usage(read_token())
+        except subprocess.CalledProcessError:
+            sys.exit("keychain read failed (locked, denied, or item missing) — card left unchanged")
+        except urllib.error.HTTPError as e:
+            if e.code == 401:
+                sys.exit("401 unauthorized: token expired — open Claude Code once to refresh, or add refresh support")
+            sys.exit(f"HTTP {e.code} from usage endpoint — card left unchanged")
+        except urllib.error.URLError as e:
+            sys.exit(f"network error: {e.reason} — card left unchanged")
+
+    if "--debug" in sys.argv and not src:
+        RAW.write_text(json.dumps(data, indent=2, ensure_ascii=False))
+        print(f"raw response saved to {RAW}")
+
+    snap = build(data, now)
+    if snap is None:
+        hint = "" if ("--debug" in sys.argv or src) else f"; re-run with --debug to dump the shape to {RAW}"
+        sys.exit("no rate-limit windows found in response — card left unchanged" + hint)
+    write_atomic(snap)
+    print("card updated: " + " · ".join(m["formattedValue"] for m in snap["metrics"]))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Context of Contribution

- [ ] Bug Fix
- [ ] Refactoring
- [ ] New Feature
- [x] Others (documentation + sample under docs/samples/claude-code)

## Summary of the Proposal

<img width="221" height="131" alt="Claude usage" src="https://github.com/user-attachments/assets/12242e34-b215-486a-b33d-3addce80d4b2" />

Extends the `docs/samples/claude-code` sample with usage-limit guidance for the Custom Metrics card:

- `USAGE-OUT-OF-BAND.md` (new) — documents the `rate_limits.{five_hour,seven_day}` statusLine fields, a supported snippet for reset countdowns (`resets_at`), the finding that no supported API exposes subscription 5h/7d usage out of band, an unofficial/experimental poller for those who want it anyway, and a full reference of the usage payload so users can build any card row they like.
- `runcat-usage-poll.py` (new) — the poller: reads Claude Code's Keychain OAuth token and calls the undocumented endpoint behind `/usage`, writing the standard `runcat-usage.json` card with no Claude Code session running. Ships `--selftest`, `--debug`, `--from`.
- `com.example.runcat-usage-poll.plist` (new) — sample launchd agent.
- `README.md` — one pointer to the new doc.

The out-of-band poller is intentionally isolated in its own file and a clearly-labeled section: it relies on an undocumented internal endpoint and reads Claude Code's OAuth token, so it will break if Anthropic changes either, and automated calls to a non-public endpoint may run against Anthropic's ToS. Happy to drop it and keep only the supported findings if maintainers prefer. macOS-only; docs/samples only — no app code changed.

## Reason for the new feature

N/A — documentation/sample, not an app feature. The stock statusLine card only refreshes during an active Claude Code session; this documents that limitation and the usage-payload fields so users can customize the card, with an optional caveated path for out-of-band updates.

## Checklist

- [x] I have read the CONTRIBUTING.md and agree to follow it.
- [x] This PR does not contain commits of multiple contexts.
- [x] Code follows proper indentation and naming conventions.
- [x] Implemented using only APIs that can be submitted to the App Store. (docs/samples only; no app code changed)
