### PR TITLE
Allow reordering custom metrics sources

### DIFF
--- a/LocalPackage/Sources/Model/Stores/CustomMetricsSettings.swift
+++ b/LocalPackage/Sources/Model/Stores/CustomMetricsSettings.swift
@@ -115,6 +115,21 @@ public final class CustomMetricsSettings: Composable {
         case .removingCustomMetricsSourceCancelled:
             pendingRemovalSourceID = nil
 
+        case let .customMetricsSourcesMoved(sourceOffsets, destinationOffset):
+            let movedSources = sourceOffsets.map { customMetricsSources[$0] }
+            for sourceOffset in sourceOffsets.reversed() {
+                customMetricsSources.remove(at: sourceOffset)
+            }
+            let removedSourceCount = sourceOffsets.count { $0 < destinationOffset }
+            customMetricsSources.insert(
+                contentsOf: movedSources,
+                at: destinationOffset - removedSourceCount
+            )
+            var configuration = userDefaultsRepository.customMetricsConfiguration
+            configuration.sources = customMetricsSources
+            userDefaultsRepository.customMetricsConfiguration = configuration
+            customMetricsService.emitConfigurationChange()
+
         case let .customMetricsSourceLinkTapped(source):
             do {
                 try customMetricsService.perform(
@@ -150,6 +165,7 @@ public final class CustomMetricsSettings: Composable {
         case removeCustomMetricsSourceButtonTapped(UUID)
         case removingCustomMetricsSourceConfirmed
         case removingCustomMetricsSourceCancelled
+        case customMetricsSourcesMoved(IndexSet, Int)
         case customMetricsSourceLinkTapped(CustomMetricsSource)
         case onError(RCNError)
     }

--- a/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSettingsSectionView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSettingsSectionView.swift
@@ -38,6 +38,11 @@ struct CustomMetricsSettingsSectionView: View {
                     }
                 )
             }
+            .onMove { sourceOffsets, destinationOffset in
+                Task {
+                    await store.send(.customMetricsSourcesMoved(sourceOffsets, destinationOffset))
+                }
+            }
             HStack {
                 Spacer()
                 Button {

--- a/LocalPackage/Tests/ModelTests/StoreTests/CustomMetricsSettingsTests.swift
+++ b/LocalPackage/Tests/ModelTests/StoreTests/CustomMetricsSettingsTests.swift
@@ -235,6 +235,30 @@ struct CustomMetricsSettingsTests {
     }
 
     @MainActor @Test
+    func send_customMetricsSourcesMoved_reorders_sources_persists_and_emits_change() async {
+        let appState = AllocatedUnfairLock<AppState>(initialState: .init())
+        let sources = (1...3).map {
+            CustomMetricsSource(
+                id: UUID($0),
+                displayName: "Source \($0)",
+                fileURL: URL(filePath: "/tmp/source-\($0).json"),
+                bookmark: Data(),
+                createdAt: Date(timeIntervalSince1970: 0)
+            )
+        }
+        let storage = UserDefaultsClient.storage(initialSources: sources)
+        let sut = CustomMetricsSettings(.testDependencies(
+            appStateClient: .testDependency(appState),
+            userDefaultsClient: storage.client
+        ))
+        await sut.send(.customMetricsSourcesMoved([0], 3))
+        let expectedSources = [sources[1], sources[2], sources[0]]
+        #expect(sut.customMetricsSources == expectedSources)
+        #expect(storage.currentConfiguration()?.sources == expectedSources)
+        #expect(appState.withLock(\.customMetricsConfigurationChanges.latestValue) != nil)
+    }
+
+    @MainActor @Test
     func send_customMetricsSourceLinkTapped_activates_file_viewer_with_resolved_url() async {
         let resolvedURL = URL(filePath: "/tmp/resolved.json")
         let activatedURLs = AllocatedUnfairLock<[URL]>(initialState: [])


### PR DESCRIPTION
## Context of Contribution

- [ ] Bug Fix
- [ ] Refactoring
- [x] New Feature
- [ ] Others

## Summary of the Proposal

Allow users to drag custom metrics sources into their preferred order in Metrics settings. The new order is persisted in the existing custom metrics configuration and applied immediately to custom metrics displays.

A store test covers reordering, persistence, and configuration change notification.

## Reason for the new feature

Users with multiple custom metrics sources currently have to remove and re-add sources to change their display order. Native SwiftUI row reordering provides direct control without adding new settings or dependencies.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) and agree to follow it.
- [x] This PR does not contain commits of multiple contexts.
- [x] Code follows proper indentation and naming conventions.
- [x] Implemented using only APIs that can be submitted to the App Store.

## Verification

- 166 tests passed with the UnitTest test plan on macOS arm64.
- Release build succeeded.