### PR TITLE
Allow reordering custom metrics sources

### DIFF
--- a/LocalPackage/Sources/Model/Stores/CustomMetricsSettings.swift
+++ b/LocalPackage/Sources/Model/Stores/CustomMetricsSettings.swift
@@ -115,16 +115,14 @@ public final class CustomMetricsSettings: Composable {
         case .removingCustomMetricsSourceCancelled:
             pendingRemovalSourceID = nil
 
-        case let .customMetricsSourcesMoved(sourceOffsets, destinationOffset):
-            let movedSources = sourceOffsets.map { customMetricsSources[$0] }
-            for sourceOffset in sourceOffsets.reversed() {
-                customMetricsSources.remove(at: sourceOffset)
+        case let .customMetricsSourceMoved(sourceID, destinationID):
+            guard let sourceIndex = customMetricsSources.firstIndex(where: { $0.id == sourceID }),
+                  let destinationIndex = customMetricsSources.firstIndex(where: { $0.id == destinationID }),
+                  sourceIndex != destinationIndex else {
+                return
             }
-            let removedSourceCount = sourceOffsets.count { $0 < destinationOffset }
-            customMetricsSources.insert(
-                contentsOf: movedSources,
-                at: destinationOffset - removedSourceCount
-            )
+            let source = customMetricsSources.remove(at: sourceIndex)
+            customMetricsSources.insert(source, at: destinationIndex)
             var configuration = userDefaultsRepository.customMetricsConfiguration
             configuration.sources = customMetricsSources
             userDefaultsRepository.customMetricsConfiguration = configuration
@@ -165,7 +163,7 @@ public final class CustomMetricsSettings: Composable {
         case removeCustomMetricsSourceButtonTapped(UUID)
         case removingCustomMetricsSourceConfirmed
         case removingCustomMetricsSourceCancelled
-        case customMetricsSourcesMoved(IndexSet, Int)
+        case customMetricsSourceMoved(UUID, UUID)
         case customMetricsSourceLinkTapped(CustomMetricsSource)
         case onError(RCNError)
     }

--- a/LocalPackage/Sources/Model/Stores/CustomMetricsSettings.swift
+++ b/LocalPackage/Sources/Model/Stores/CustomMetricsSettings.swift
@@ -115,6 +115,21 @@ public final class CustomMetricsSettings: Composable {
         case .removingCustomMetricsSourceCancelled:
             pendingRemovalSourceID = nil
 
+        case let .customMetricsSourcesMoved(sourceOffsets, destinationOffset):
+            let movedSources = sourceOffsets.map { customMetricsSources[$0] }
+            for sourceOffset in sourceOffsets.reversed() {
+                customMetricsSources.remove(at: sourceOffset)
+            }
+            let removedSourceCount = sourceOffsets.count { $0 < destinationOffset }
+            customMetricsSources.insert(
+                contentsOf: movedSources,
+                at: destinationOffset - removedSourceCount
+            )
+            var configuration = userDefaultsRepository.customMetricsConfiguration
+            configuration.sources = customMetricsSources
+            userDefaultsRepository.customMetricsConfiguration = configuration
+            customMetricsService.emitConfigurationChange()
+
         case let .customMetricsSourceLinkTapped(source):
             do {
                 try customMetricsService.perform(
@@ -150,6 +165,7 @@ public final class CustomMetricsSettings: Composable {
         case removeCustomMetricsSourceButtonTapped(UUID)
         case removingCustomMetricsSourceConfirmed
         case removingCustomMetricsSourceCancelled
+        case customMetricsSourcesMoved(IndexSet, Int)
         case customMetricsSourceLinkTapped(CustomMetricsSource)
         case onError(RCNError)
     }

--- a/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSettingsSectionView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSettingsSectionView.swift
@@ -39,21 +39,23 @@ struct CustomMetricsSettingsSectionView: View {
                         await store.send(.customMetricsSourceLinkTapped(source))
                     }
                 )
+                .opacity(draggedSourceID == source.id ? 0 : 1)
                 .onDrag {
                     draggedSourceID = source.id
                     return NSItemProvider(object: source.id.uuidString as NSString)
                 }
-                .onDrop(of: [.text], isTargeted: nil) { _ in
-                    guard let draggedSourceID,
-                          draggedSourceID != source.id else {
-                        return false
-                    }
-                    Task {
-                        await store.send(.customMetricsSourceMoved(draggedSourceID, source.id))
-                    }
-                    self.draggedSourceID = nil
-                    return true
-                }
+                .onDrop(
+                    of: [.text],
+                    delegate: CustomMetricsSourceDropDelegate(
+                        destinationSourceID: source.id,
+                        draggedSourceID: $draggedSourceID,
+                        move: { sourceID, destinationID in
+                            Task {
+                                await store.send(.customMetricsSourceMoved(sourceID, destinationID))
+                            }
+                        }
+                    )
+                )
             }
             HStack {
                 Spacer()
@@ -137,5 +139,28 @@ struct CustomMetricsSettingsSectionView: View {
                 await store.send(.onDisappear)
             }
         }
+    }
+}
+
+private struct CustomMetricsSourceDropDelegate: DropDelegate {
+    var destinationSourceID: UUID
+    @Binding var draggedSourceID: UUID?
+    var move: (UUID, UUID) -> Void
+
+    func dropEntered(info: DropInfo) {
+        guard let draggedSourceID,
+              draggedSourceID != destinationSourceID else {
+            return
+        }
+        move(draggedSourceID, destinationSourceID)
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        DropProposal(operation: .move)
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        draggedSourceID = nil
+        return true
     }
 }

--- a/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSettingsSectionView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSettingsSectionView.swift
@@ -37,10 +37,16 @@ struct CustomMetricsSettingsSectionView: View {
                         await store.send(.customMetricsSourceLinkTapped(source))
                     }
                 )
-            }
-            .onMove { sourceOffsets, destinationOffset in
-                Task {
-                    await store.send(.customMetricsSourcesMoved(sourceOffsets, destinationOffset))
+                .dropDestination(for: String.self) { items, _ in
+                    guard let value = items.first,
+                          let sourceID = UUID(uuidString: value),
+                          sourceID != source.id else {
+                        return false
+                    }
+                    Task {
+                        await store.send(.customMetricsSourceMoved(sourceID, source.id))
+                    }
+                    return true
                 }
             }
             HStack {

--- a/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSettingsSectionView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSettingsSectionView.swift
@@ -38,6 +38,11 @@ struct CustomMetricsSettingsSectionView: View {
                     }
                 )
             }
+            .onMove { sourceOffsets, destinationOffset in
+                Task {
+                    await store.send(.customMetricsSourcesMoved(sourceOffsets, destinationOffset))
+                }
+            }
             HStack {
                 Spacer()
                 Button {

--- a/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSettingsSectionView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSettingsSectionView.swift
@@ -96,6 +96,11 @@ struct CustomMetricsSettingsSectionView: View {
         } header: {
             Text("customMetrics", bundle: .module)
         }
+        .simultaneousGesture(
+            DragGesture().onEnded { _ in
+                draggedSourceID = nil
+            }
+        )
         .fileImporter(
             isPresented: $store.showingFileImporter,
             allowedContentTypes: [.json],

--- a/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSettingsSectionView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSettingsSectionView.swift
@@ -18,13 +18,15 @@
  limitations under the License.
  */
 
+import AppKit
 import Model
+import Observation
 import SwiftUI
 import UniformTypeIdentifiers
 
 struct CustomMetricsSettingsSectionView: View {
     @State var store: CustomMetricsSettings
-    @State private var draggedSourceID: UUID?
+    @State private var dragState = CustomMetricsSourceDragState()
 
     var body: some View {
         Section {
@@ -39,16 +41,16 @@ struct CustomMetricsSettingsSectionView: View {
                         await store.send(.customMetricsSourceLinkTapped(source))
                     }
                 )
-                .opacity(draggedSourceID == source.id ? 0 : 1)
+                .opacity(dragState.sourceID == source.id ? 0 : 1)
                 .onDrag {
-                    draggedSourceID = source.id
+                    dragState.begin(sourceID: source.id)
                     return NSItemProvider(object: source.id.uuidString as NSString)
                 }
                 .onDrop(
                     of: [.text],
                     delegate: CustomMetricsSourceDropDelegate(
                         destinationSourceID: source.id,
-                        draggedSourceID: $draggedSourceID,
+                        dragState: dragState,
                         move: { sourceID, destinationID in
                             Task {
                                 await store.send(.customMetricsSourceMoved(sourceID, destinationID))
@@ -96,11 +98,6 @@ struct CustomMetricsSettingsSectionView: View {
         } header: {
             Text("customMetrics", bundle: .module)
         }
-        .simultaneousGesture(
-            DragGesture().onEnded { _ in
-                draggedSourceID = nil
-            }
-        )
         .fileImporter(
             isPresented: $store.showingFileImporter,
             allowedContentTypes: [.json],
@@ -140,6 +137,7 @@ struct CustomMetricsSettingsSectionView: View {
             await store.send(.task)
         }
         .onDisappear {
+            dragState.end()
             Task {
                 await store.send(.onDisappear)
             }
@@ -147,13 +145,36 @@ struct CustomMetricsSettingsSectionView: View {
     }
 }
 
+@MainActor @Observable
+private final class CustomMetricsSourceDragState {
+    var sourceID: UUID?
+
+    @ObservationIgnored private var mouseUpMonitor: Any?
+
+    func begin(sourceID: UUID) {
+        self.sourceID = sourceID
+        guard mouseUpMonitor == nil else { return }
+        mouseUpMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseUp) { [weak self] event in
+            self?.end()
+            return event
+        }
+    }
+
+    func end() {
+        sourceID = nil
+        guard let mouseUpMonitor else { return }
+        NSEvent.removeMonitor(mouseUpMonitor)
+        self.mouseUpMonitor = nil
+    }
+}
+
 private struct CustomMetricsSourceDropDelegate: DropDelegate {
     var destinationSourceID: UUID
-    @Binding var draggedSourceID: UUID?
+    var dragState: CustomMetricsSourceDragState
     var move: (UUID, UUID) -> Void
 
     func dropEntered(info: DropInfo) {
-        guard let draggedSourceID,
+        guard let draggedSourceID = dragState.sourceID,
               draggedSourceID != destinationSourceID else {
             return
         }
@@ -165,7 +186,7 @@ private struct CustomMetricsSourceDropDelegate: DropDelegate {
     }
 
     func performDrop(info: DropInfo) -> Bool {
-        draggedSourceID = nil
+        dragState.end()
         return true
     }
 }

--- a/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSettingsSectionView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSettingsSectionView.swift
@@ -20,9 +20,11 @@
 
 import Model
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct CustomMetricsSettingsSectionView: View {
     @State var store: CustomMetricsSettings
+    @State private var draggedSourceID: UUID?
 
     var body: some View {
         Section {
@@ -37,15 +39,19 @@ struct CustomMetricsSettingsSectionView: View {
                         await store.send(.customMetricsSourceLinkTapped(source))
                     }
                 )
-                .dropDestination(for: String.self) { items, _ in
-                    guard let value = items.first,
-                          let sourceID = UUID(uuidString: value),
-                          sourceID != source.id else {
+                .onDrag {
+                    draggedSourceID = source.id
+                    return NSItemProvider(object: source.id.uuidString as NSString)
+                }
+                .onDrop(of: [.text], isTargeted: nil) { _ in
+                    guard let draggedSourceID,
+                          draggedSourceID != source.id else {
                         return false
                     }
                     Task {
-                        await store.send(.customMetricsSourceMoved(sourceID, source.id))
+                        await store.send(.customMetricsSourceMoved(draggedSourceID, source.id))
                     }
+                    self.draggedSourceID = nil
                     return true
                 }
             }

--- a/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSettingsSectionView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSettingsSectionView.swift
@@ -34,6 +34,9 @@ struct CustomMetricsSettingsSectionView: View {
                 CustomMetricsSourceRowView(
                     source: source,
                     isErrorDetected: store.failedCustomMetricsSourceIDs.contains(source.id),
+                    dragStarted: {
+                        dragState.begin(sourceID: source.id)
+                    },
                     removeButtonTapped: {
                         await store.send(.removeCustomMetricsSourceButtonTapped(source.id))
                     },
@@ -41,11 +44,7 @@ struct CustomMetricsSettingsSectionView: View {
                         await store.send(.customMetricsSourceLinkTapped(source))
                     }
                 )
-                .opacity(dragState.sourceID == source.id ? 0 : 1)
-                .onDrag {
-                    dragState.begin(sourceID: source.id)
-                    return NSItemProvider(object: source.id.uuidString as NSString)
-                }
+                .opacity(dragState.hiddenSourceID == source.id ? 0 : 1)
                 .onDrop(
                     of: [.text],
                     delegate: CustomMetricsSourceDropDelegate(
@@ -148,11 +147,15 @@ struct CustomMetricsSettingsSectionView: View {
 @MainActor @Observable
 private final class CustomMetricsSourceDragState {
     var sourceID: UUID?
+    var hiddenSourceID: UUID?
 
     @ObservationIgnored private var mouseUpMonitor: Any?
+    @ObservationIgnored private var revealTask: Task<Void, Never>?
 
     func begin(sourceID: UUID) {
+        revealTask?.cancel()
         self.sourceID = sourceID
+        hiddenSourceID = sourceID
         guard mouseUpMonitor == nil else { return }
         mouseUpMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseUp) { [weak self] event in
             self?.end()
@@ -161,10 +164,20 @@ private final class CustomMetricsSourceDragState {
     }
 
     func end() {
+        let wasDragging = sourceID != nil
         sourceID = nil
-        guard let mouseUpMonitor else { return }
-        NSEvent.removeMonitor(mouseUpMonitor)
-        self.mouseUpMonitor = nil
+        if let mouseUpMonitor {
+            NSEvent.removeMonitor(mouseUpMonitor)
+            self.mouseUpMonitor = nil
+        }
+        guard wasDragging else { return }
+        revealTask?.cancel()
+        revealTask = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(200))
+            guard !Task.isCancelled else { return }
+            self?.hiddenSourceID = nil
+            self?.revealTask = nil
+        }
     }
 }
 

--- a/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSourceRowView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSourceRowView.swift
@@ -29,6 +29,9 @@ struct CustomMetricsSourceRowView: View {
 
     var body: some View {
         LabeledContent {
+            Image(systemName: "line.3.horizontal")
+                .foregroundStyle(.secondary)
+                .draggable(source.id.uuidString)
             Button(role: .destructive) {
                 Task {
                     await removeButtonTapped()

--- a/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSourceRowView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSourceRowView.swift
@@ -22,8 +22,6 @@ import DataSource
 import SwiftUI
 
 struct CustomMetricsSourceRowView: View {
-    @State private var rowSize: CGSize = .zero
-
     var source: CustomMetricsSource
     var isErrorDetected: Bool
     var dragStarted: () -> Void
@@ -58,31 +56,6 @@ struct CustomMetricsSourceRowView: View {
             }
             .frame(width: 24)
             .frame(maxHeight: .infinity)
-            .onDrag {
-                dragStarted()
-                return NSItemProvider(object: source.id.uuidString as NSString)
-            } preview: {
-                HStack {
-                    VStack(alignment: .leading) {
-                        Text(source.displayName)
-                            .truncationMode(.middle)
-                        HStack(spacing: 8) {
-                            Text(LocalizedStringKey(stringLiteral: "\(source.fileURL.relativePath) [→](/)"))
-                            if isErrorDetected {
-                                Text("errorDetected", bundle: .module)
-                                    .foregroundStyle(Color.yellow)
-                            }
-                        }
-                    }
-                    Spacer()
-                    Image(systemName: "line.3.horizontal")
-                        .foregroundStyle(.secondary)
-                        .frame(width: 24)
-                    Image(systemName: "minus.circle")
-                        .foregroundStyle(Color.red)
-                }
-                .frame(width: rowSize.width, height: rowSize.height)
-            }
             Button(role: .destructive) {
                 Task {
                     await removeButtonTapped()
@@ -92,11 +65,19 @@ struct CustomMetricsSourceRowView: View {
                     .foregroundStyle(Color.red)
             }
             .buttonStyle(.borderless)
+            .frame(width: 24)
         }
-        .onGeometryChange(for: CGSize.self) { proxy in
-            proxy.size
-        } action: { size in
-            rowSize = size
+        .contentShape(.interaction, CustomMetricsSourceDragHandleShape())
+        .contentShape(.dragPreview, Rectangle())
+        .onDrag {
+            dragStarted()
+            return NSItemProvider(object: source.id.uuidString as NSString)
         }
+    }
+}
+
+private struct CustomMetricsSourceDragHandleShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        Path(CGRect(x: rect.maxX - 56, y: rect.minY, width: 24, height: rect.height))
     }
 }

--- a/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSourceRowView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSourceRowView.swift
@@ -29,16 +29,33 @@ struct CustomMetricsSourceRowView: View {
     var sourceLinkTapped: () async -> Void
 
     var body: some View {
-        LabeledContent {
-            VStack(spacing: 0) {
-                Spacer(minLength: 0)
+        HStack {
+            VStack(alignment: .leading) {
+                Text(source.displayName)
+                    .truncationMode(.middle)
+                HStack(spacing: 8) {
+                    Text(LocalizedStringKey(stringLiteral: "\(source.fileURL.relativePath) [→](/)"))
+                        .environment(\.openURL, OpenURLAction { _ in
+                            Task {
+                                await sourceLinkTapped()
+                            }
+                            return .handled
+                        })
+                    if isErrorDetected {
+                        Text("errorDetected", bundle: .module)
+                            .foregroundStyle(Color.yellow)
+                    }
+                }
+            }
+            Spacer()
+            ZStack {
+                Color.clear
+                    .contentShape(Rectangle())
                 Image(systemName: "line.3.horizontal")
                     .foregroundStyle(.secondary)
-                Spacer(minLength: 0)
             }
             .frame(width: 24)
             .frame(maxHeight: .infinity)
-            .contentShape(Rectangle())
             .onDrag {
                 dragStarted()
                 return NSItemProvider(object: source.id.uuidString as NSString)
@@ -52,22 +69,6 @@ struct CustomMetricsSourceRowView: View {
                     .foregroundStyle(Color.red)
             }
             .buttonStyle(.borderless)
-        } label: {
-            Text(source.displayName)
-                .truncationMode(.middle)
-            HStack(spacing: 8) {
-                Text(LocalizedStringKey(stringLiteral: "\(source.fileURL.relativePath) [→](/)"))
-                    .environment(\.openURL, OpenURLAction { _ in
-                        Task {
-                            await sourceLinkTapped()
-                        }
-                        return .handled
-                    })
-                if isErrorDetected {
-                    Text("errorDetected", bundle: .module)
-                        .foregroundStyle(Color.yellow)
-                }
-            }
         }
     }
 }

--- a/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSourceRowView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSourceRowView.swift
@@ -22,6 +22,9 @@ import DataSource
 import SwiftUI
 
 struct CustomMetricsSourceRowView: View {
+    private let controlWidth: CGFloat = 24
+    private let controlSpacing: CGFloat = 8
+
     var source: CustomMetricsSource
     var isErrorDetected: Bool
     var dragStarted: () -> Void
@@ -29,45 +32,46 @@ struct CustomMetricsSourceRowView: View {
     var sourceLinkTapped: () async -> Void
 
     var body: some View {
-        HStack {
-            VStack(alignment: .leading) {
-                Text(source.displayName)
-                    .truncationMode(.middle)
-                HStack(spacing: 8) {
-                    Text(LocalizedStringKey(stringLiteral: "\(source.fileURL.relativePath) [→](/)"))
-                        .environment(\.openURL, OpenURLAction { _ in
-                            Task {
-                                await sourceLinkTapped()
-                            }
-                            return .handled
-                        })
-                    if isErrorDetected {
-                        Text("errorDetected", bundle: .module)
-                            .foregroundStyle(Color.yellow)
-                    }
-                }
-            }
-            Spacer()
-            ZStack {
-                Color.clear
-                    .contentShape(Rectangle())
+        LabeledContent {
+            HStack(spacing: controlSpacing) {
                 Image(systemName: "line.3.horizontal")
                     .foregroundStyle(.secondary)
-            }
-            .frame(width: 24)
-            .frame(maxHeight: .infinity)
-            Button(role: .destructive) {
-                Task {
-                    await removeButtonTapped()
+                    .frame(width: controlWidth)
+                Button(role: .destructive) {
+                    Task {
+                        await removeButtonTapped()
+                    }
+                } label: {
+                    Image(systemName: "minus.circle")
+                        .foregroundStyle(Color.red)
                 }
-            } label: {
-                Image(systemName: "minus.circle")
-                    .foregroundStyle(Color.red)
+                .buttonStyle(.borderless)
+                .frame(width: controlWidth)
             }
-            .buttonStyle(.borderless)
-            .frame(width: 24)
+        } label: {
+            Text(source.displayName)
+                .truncationMode(.middle)
+            HStack(spacing: 8) {
+                Text(LocalizedStringKey(stringLiteral: "\(source.fileURL.relativePath) [→](/)"))
+                    .environment(\.openURL, OpenURLAction { _ in
+                        Task {
+                            await sourceLinkTapped()
+                        }
+                        return .handled
+                    })
+                if isErrorDetected {
+                    Text("errorDetected", bundle: .module)
+                        .foregroundStyle(Color.yellow)
+                }
+            }
         }
-        .contentShape(.interaction, CustomMetricsSourceDragHandleShape())
+        .contentShape(
+            .interaction,
+            CustomMetricsSourceDragHandleShape(
+                width: controlWidth,
+                trailingInset: controlWidth + controlSpacing
+            )
+        )
         .contentShape(.dragPreview, Rectangle())
         .onDrag {
             dragStarted()
@@ -77,7 +81,15 @@ struct CustomMetricsSourceRowView: View {
 }
 
 private struct CustomMetricsSourceDragHandleShape: Shape {
+    var width: CGFloat
+    var trailingInset: CGFloat
+
     func path(in rect: CGRect) -> Path {
-        Path(CGRect(x: rect.maxX - 56, y: rect.minY, width: 24, height: rect.height))
+        Path(CGRect(
+            x: rect.maxX - trailingInset - width,
+            y: rect.minY,
+            width: width,
+            height: rect.height
+        ))
     }
 }

--- a/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSourceRowView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSourceRowView.swift
@@ -24,13 +24,25 @@ import SwiftUI
 struct CustomMetricsSourceRowView: View {
     var source: CustomMetricsSource
     var isErrorDetected: Bool
+    var dragStarted: () -> Void
     var removeButtonTapped: () async -> Void
     var sourceLinkTapped: () async -> Void
 
     var body: some View {
         LabeledContent {
-            Image(systemName: "line.3.horizontal")
-                .foregroundStyle(.secondary)
+            VStack(spacing: 0) {
+                Spacer(minLength: 0)
+                Image(systemName: "line.3.horizontal")
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 0)
+            }
+            .frame(width: 24)
+            .frame(maxHeight: .infinity)
+            .contentShape(Rectangle())
+            .onDrag {
+                dragStarted()
+                return NSItemProvider(object: source.id.uuidString as NSString)
+            }
             Button(role: .destructive) {
                 Task {
                     await removeButtonTapped()

--- a/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSourceRowView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSourceRowView.swift
@@ -22,6 +22,8 @@ import DataSource
 import SwiftUI
 
 struct CustomMetricsSourceRowView: View {
+    @State private var rowSize: CGSize = .zero
+
     var source: CustomMetricsSource
     var isErrorDetected: Bool
     var dragStarted: () -> Void
@@ -59,6 +61,27 @@ struct CustomMetricsSourceRowView: View {
             .onDrag {
                 dragStarted()
                 return NSItemProvider(object: source.id.uuidString as NSString)
+            } preview: {
+                HStack {
+                    VStack(alignment: .leading) {
+                        Text(source.displayName)
+                            .truncationMode(.middle)
+                        HStack(spacing: 8) {
+                            Text(LocalizedStringKey(stringLiteral: "\(source.fileURL.relativePath) [→](/)"))
+                            if isErrorDetected {
+                                Text("errorDetected", bundle: .module)
+                                    .foregroundStyle(Color.yellow)
+                            }
+                        }
+                    }
+                    Spacer()
+                    Image(systemName: "line.3.horizontal")
+                        .foregroundStyle(.secondary)
+                        .frame(width: 24)
+                    Image(systemName: "minus.circle")
+                        .foregroundStyle(Color.red)
+                }
+                .frame(width: rowSize.width, height: rowSize.height)
             }
             Button(role: .destructive) {
                 Task {
@@ -69,6 +92,11 @@ struct CustomMetricsSourceRowView: View {
                     .foregroundStyle(Color.red)
             }
             .buttonStyle(.borderless)
+        }
+        .onGeometryChange(for: CGSize.self) { proxy in
+            proxy.size
+        } action: { size in
+            rowSize = size
         }
     }
 }

--- a/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSourceRowView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSourceRowView.swift
@@ -31,7 +31,6 @@ struct CustomMetricsSourceRowView: View {
         LabeledContent {
             Image(systemName: "line.3.horizontal")
                 .foregroundStyle(.secondary)
-                .draggable(source.id.uuidString)
             Button(role: .destructive) {
                 Task {
                     await removeButtonTapped()

--- a/LocalPackage/Tests/ModelTests/StoreTests/CustomMetricsSettingsTests.swift
+++ b/LocalPackage/Tests/ModelTests/StoreTests/CustomMetricsSettingsTests.swift
@@ -235,7 +235,7 @@ struct CustomMetricsSettingsTests {
     }
 
     @MainActor @Test
-    func send_customMetricsSourcesMoved_reorders_sources_persists_and_emits_change() async {
+    func send_customMetricsSourceMoved_reorders_sources_persists_and_emits_change() async {
         let appState = AllocatedUnfairLock<AppState>(initialState: .init())
         let sources = (1...3).map {
             CustomMetricsSource(
@@ -251,7 +251,7 @@ struct CustomMetricsSettingsTests {
             appStateClient: .testDependency(appState),
             userDefaultsClient: storage.client
         ))
-        await sut.send(.customMetricsSourcesMoved([0], 3))
+        await sut.send(.customMetricsSourceMoved(sources[0].id, sources[2].id))
         let expectedSources = [sources[1], sources[2], sources[0]]
         #expect(sut.customMetricsSources == expectedSources)
         #expect(storage.currentConfiguration()?.sources == expectedSources)

--- a/LocalPackage/Tests/ModelTests/StoreTests/CustomMetricsSettingsTests.swift
+++ b/LocalPackage/Tests/ModelTests/StoreTests/CustomMetricsSettingsTests.swift
@@ -235,6 +235,30 @@ struct CustomMetricsSettingsTests {
     }
 
     @MainActor @Test
+    func send_customMetricsSourcesMoved_reorders_sources_persists_and_emits_change() async {
+        let appState = AllocatedUnfairLock<AppState>(initialState: .init())
+        let sources = (1...3).map {
+            CustomMetricsSource(
+                id: UUID($0),
+                displayName: "Source \($0)",
+                fileURL: URL(filePath: "/tmp/source-\($0).json"),
+                bookmark: Data(),
+                createdAt: Date(timeIntervalSince1970: 0)
+            )
+        }
+        let storage = UserDefaultsClient.storage(initialSources: sources)
+        let sut = CustomMetricsSettings(.testDependencies(
+            appStateClient: .testDependency(appState),
+            userDefaultsClient: storage.client
+        ))
+        await sut.send(.customMetricsSourcesMoved([0], 3))
+        let expectedSources = [sources[1], sources[2], sources[0]]
+        #expect(sut.customMetricsSources == expectedSources)
+        #expect(storage.currentConfiguration()?.sources == expectedSources)
+        #expect(appState.withLock(\.customMetricsConfigurationChanges.latestValue) != nil)
+    }
+
+    @MainActor @Test
     func send_customMetricsSourceLinkTapped_activates_file_viewer_with_resolved_url() async {
         let resolvedURL = URL(filePath: "/tmp/resolved.json")
         let activatedURLs = AllocatedUnfairLock<[URL]>(initialState: [])


### PR DESCRIPTION
## Context of Contribution

- [ ] Bug Fix
- [ ] Refactoring
- [x] New Feature
- [ ] Others

## Summary of the Proposal

Allow users to reorder custom metrics sources by dragging the handle in Metrics settings.

The new order is persisted in the existing custom metrics configuration and immediately applied to custom metrics displays.

## Reason for the new feature

Users with multiple custom metrics sources currently need to remove and re-add sources to change their display order.

This change uses the existing source array as the display order, adds no new settings or dependencies, and follows the drag-and-drop pattern already used by the custom runner frame editor.

## Verification

- Confirmed drag handles use the full row height as their hit area.
- Confirmed surrounding rows move to preview the destination while dragging.
- Confirmed the dragged row is restored after dropping.
- Confirmed the reordered sources persist and emit a configuration change.
- 166 tests passed on macOS arm64.
- Release build succeeded.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) and agree to follow it.
- [x] This PR does not contain commits of multiple contexts.
- [x] Code follows proper indentation and naming conventions.
- [x] Implemented using only APIs that can be submitted to the App Store.


https://github.com/user-attachments/assets/683a5b86-e73c-456f-a9b6-69000cceae56