### PR TITLE
Add rate-limit reset time to Claude Code statusline sample

### DIFF
--- a/docs/samples/claude-code/README.md
+++ b/docs/samples/claude-code/README.md
@@ -4,13 +4,13 @@ A minimal Python script that lets RunCat Neo's Custom Metrics card show your Cla
 
 **Displays:**
 - Current model name
-- 5-hour rate limit usage (with progress bar)
-- 7-day rate limit usage (with progress bar)
+- 5-hour rate limit usage (with progress bar and reset time, e.g. `69% (~14:30)`)
+- 7-day rate limit usage (with progress bar and reset time)
 
 ## Requirements
 
-- Claude desktop app (the script reads rate limit data from `~/Library/Application Support/Claude/plan-usage-history.json`)
-- Claude Code CLI
+- Claude desktop app (the script reads rate limit percentages from `~/Library/Application Support/Claude/plan-usage-history.json`)
+- Claude Code CLI recent enough to include `rate_limits` in the statusLine payload — older versions omit reset times, and the script just drops the `(~...)` suffix
 
 ## Setup
 
@@ -45,7 +45,7 @@ The output JSON shape is documented in [`../../CustomMetricsSchema.md`](../../Cu
 
 ## How It Works
 
-The script reads rate limit data from Claude desktop app's usage history file (`~/Library/Application Support/Claude/plan-usage-history.json`). This file is updated automatically by the Claude app and contains the most recent 5-hour and 7-day usage percentages.
+The script reads rate limit percentages from Claude desktop app's usage history file (`~/Library/Application Support/Claude/plan-usage-history.json`). This file is updated automatically by the Claude app and contains the most recent 5-hour and 7-day usage percentages. Reset times aren't in that file — they come from the `rate_limits.five_hour.resets_at` / `rate_limits.seven_day.resets_at` fields of the JSON Claude Code pipes into the statusLine command on stdin.
 
 ## Troubleshooting
 

--- a/docs/samples/claude-code/README.md
+++ b/docs/samples/claude-code/README.md
@@ -1,6 +1,16 @@
 # Claude Code Integration Sample
 
-A minimal Python script that lets RunCat Neo's Custom Metrics card show your Claude Code session at a glance. Each time Claude Code runs its statusLine command, the script writes a Custom Metrics JSON snapshot to `~/.claude/runcat-usage.json` and prints the current model name as the terminal status line.
+A minimal Python script that lets RunCat Neo's Custom Metrics card show your Claude Code rate limits at a glance. Each time Claude Code runs its statusLine command, the script reads rate limit data from Claude app's usage history and writes a Custom Metrics JSON snapshot to `~/.claude/runcat-usage.json`.
+
+**Displays:**
+- Current model name
+- 5-hour rate limit usage (with progress bar)
+- 7-day rate limit usage (with progress bar)
+
+## Requirements
+
+- Claude desktop app (the script reads rate limit data from `~/Library/Application Support/Claude/plan-usage-history.json`)
+- Claude Code CLI
 
 ## Setup
 
@@ -33,11 +43,16 @@ The output JSON shape is documented in [`../../CustomMetricsSchema.md`](../../Cu
 
 `RUNCAT_OUT_FILE` overrides where the snapshot is written (default: `~/.claude/runcat-usage.json`).
 
+## How It Works
+
+The script reads rate limit data from Claude desktop app's usage history file (`~/Library/Application Support/Claude/plan-usage-history.json`). This file is updated automatically by the Claude app and contains the most recent 5-hour and 7-day usage percentages.
+
 ## Troubleshooting
 
-- Card shows nothing → confirm Claude Code is calling the statusLine. Run the script by hand to see what it writes:
+- **Card shows only model name, no rate limits** → Make sure the Claude desktop app is installed and running. The script needs access to `~/Library/Application Support/Claude/plan-usage-history.json`.
+- **Card shows nothing** → Confirm Claude Code is calling the statusLine. Run the script by hand to see what it writes:
   ```bash
   printf '{}' | ~/.claude/runcat-statusline.py && python3 -m json.tool ~/.claude/runcat-usage.json
   ```
-- Card stays at the same values → check `~/.claude/runcat-usage.json`'s mtime. If it doesn't update on every Claude Code turn, Claude Code isn't invoking the statusLine.
-- Card footer shows **Last updated: Failed** in red → the file became unreadable. Confirm `~/.claude/runcat-usage.json` still exists, then run another Claude Code turn; the card recovers on the next successful read.
+- **Card stays at the same values** → Check `~/.claude/runcat-usage.json`'s mtime. If it doesn't update on every Claude Code turn, Claude Code isn't invoking the statusLine.
+- **Card footer shows "Last updated: Failed" in red** → The file became unreadable. Confirm `~/.claude/runcat-usage.json` still exists, then run another Claude Code turn; the card recovers on the next successful read.

--- a/docs/samples/claude-code/runcat-statusline.py
+++ b/docs/samples/claude-code/runcat-statusline.py
@@ -10,13 +10,16 @@ Writes ~/.claude/runcat-usage.json shaped like:
       "metricsBarValue": "69%",
       "metrics": [
         {"title": "Model", "formattedValue": "Sonnet 4.5"},
-        {"title": "5h", "formattedValue": "69%", "normalizedValue": 0.69},
-        {"title": "7d", "formattedValue": "12%", "normalizedValue": 0.12}
+        {"title": "5h", "formattedValue": "69% (~14:30)", "normalizedValue": 0.69},
+        {"title": "7d", "formattedValue": "12% (~7/22 03:00)", "normalizedValue": 0.12}
       ],
       "lastUpdatedDate": "2026-07-18T10:11:15Z"
     }
 
-Reads rate limit data from Claude app's plan-usage-history.json.
+Rate limit percentages come from Claude app's plan-usage-history.json. Reset
+times come from the statusLine payload's `rate_limits` field, which requires
+a recent enough Claude Code version — older versions omit it, and the "(~...)"
+suffix is simply left off.
 """
 
 import json
@@ -27,6 +30,18 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 OUT = Path(os.environ.get("RUNCAT_OUT_FILE", str(Path.home() / ".claude" / "runcat-usage.json")))
+
+
+def format_reset(epoch_seconds):
+    """Format a Unix epoch (seconds) into a short local reset time, e.g. "~14:30" or "~7/22 03:00"."""
+    if epoch_seconds is None:
+        return None
+    now = datetime.now().astimezone()
+    reset = datetime.fromtimestamp(epoch_seconds).astimezone()
+    hm = reset.strftime("%H:%M")
+    if reset.date() == now.date():
+        return f"~{hm}"
+    return f"~{reset.month}/{reset.day} {hm}"
 
 
 def format_duration(ms):
@@ -70,22 +85,32 @@ try:
 except Exception:
     pass  # If file doesn't exist or is unreadable, continue without rate limits
 
+# Reset times only come from the statusLine payload (plan-usage-history.json
+# doesn't carry them). Requires a recent enough Claude Code version.
+rate_limits = payload.get("rate_limits") or {}
+five_hour_resets_at = (rate_limits.get("five_hour") or {}).get("resets_at")
+seven_day_resets_at = (rate_limits.get("seven_day") or {}).get("resets_at")
+
 # Build metrics
 metrics = [{"title": "Model", "formattedValue": model}]
 
 # 5h rate limit
 if five_hour_pct is not None:
+    reset = format_reset(five_hour_resets_at)
+    formatted = f"{five_hour_pct}% ({reset})" if reset else f"{five_hour_pct}%"
     metrics.append({
         "title": "5h",
-        "formattedValue": f"{five_hour_pct}%",
+        "formattedValue": formatted,
         "normalizedValue": round(five_hour_pct / 100, 4)
     })
 
 # 7d rate limit
 if seven_day_pct is not None:
+    reset = format_reset(seven_day_resets_at)
+    formatted = f"{seven_day_pct}% ({reset})" if reset else f"{seven_day_pct}%"
     metrics.append({
         "title": "7d",
-        "formattedValue": f"{seven_day_pct}%",
+        "formattedValue": formatted,
         "normalizedValue": round(seven_day_pct / 100, 4)
     })
 

--- a/docs/samples/claude-code/runcat-statusline.py
+++ b/docs/samples/claude-code/runcat-statusline.py
@@ -7,15 +7,16 @@ Writes ~/.claude/runcat-usage.json shaped like:
     {
       "title": "Claude Code",
       "symbol": "staroflife",
-      "metricsBarValue": "67%",
+      "metricsBarValue": "69%",
       "metrics": [
-        {"title": "Model",   "formattedValue": "Opus 4.7"},
-        {"title": "Context", "formattedValue": "67%", "normalizedValue": 0.67},
-        {"title": "5h",      "formattedValue": "3%",  "normalizedValue": 0.03},
-        {"title": "7d",      "formattedValue": "3%",  "normalizedValue": 0.03}
+        {"title": "Model", "formattedValue": "Sonnet 4.5"},
+        {"title": "5h", "formattedValue": "69%", "normalizedValue": 0.69},
+        {"title": "7d", "formattedValue": "12%", "normalizedValue": 0.12}
       ],
-      "lastUpdatedDate": "2026-06-07T05:55:36Z"
+      "lastUpdatedDate": "2026-07-18T10:11:15Z"
     }
+
+Reads rate limit data from Claude app's plan-usage-history.json.
 """
 
 import json
@@ -28,10 +29,18 @@ from pathlib import Path
 OUT = Path(os.environ.get("RUNCAT_OUT_FILE", str(Path.home() / ".claude" / "runcat-usage.json")))
 
 
-def pct(title, value):
-    if value is None:
+def format_duration(ms):
+    """Format milliseconds to human-readable duration."""
+    if ms is None:
         return None
-    return {"title": title, "formattedValue": f"{value:g}%", "normalizedValue": round(value / 100, 4)}
+    seconds = ms / 1000
+    if seconds < 60:
+        return f"{int(seconds)}s"
+    minutes = seconds / 60
+    if minutes < 60:
+        return f"{int(minutes)}m"
+    hours = minutes / 60
+    return f"{hours:.1f}h"
 
 
 try:
@@ -41,25 +50,56 @@ try:
 except Exception:
     payload = {}
 
+# Extract data from payload
 model = (payload.get("model") or {}).get("display_name") or "Claude Code"
-ctx = (payload.get("context_window") or {}).get("used_percentage")
-rate_limits = payload.get("rate_limits") or {}
-five = (rate_limits.get("five_hour") or {}).get("used_percentage")
-seven = (rate_limits.get("seven_day") or {}).get("used_percentage")
 
+# Read rate limits from Claude app's plan usage history
+usage_file = Path.home() / "Library" / "Application Support" / "Claude" / "plan-usage-history.json"
+five_hour_pct = None
+seven_day_pct = None
+
+try:
+    with open(usage_file) as f:
+        usage_data = json.load(f)
+        if usage_data.get("samples"):
+            # Get the most recent sample
+            latest = usage_data["samples"][-1]
+            usage = latest.get("u", {})
+            five_hour_pct = usage.get("fh")  # five_hour percentage
+            seven_day_pct = usage.get("sd")  # seven_day percentage
+except Exception:
+    pass  # If file doesn't exist or is unreadable, continue without rate limits
+
+# Build metrics
+metrics = [{"title": "Model", "formattedValue": model}]
+
+# 5h rate limit
+if five_hour_pct is not None:
+    metrics.append({
+        "title": "5h",
+        "formattedValue": f"{five_hour_pct}%",
+        "normalizedValue": round(five_hour_pct / 100, 4)
+    })
+
+# 7d rate limit
+if seven_day_pct is not None:
+    metrics.append({
+        "title": "7d",
+        "formattedValue": f"{seven_day_pct}%",
+        "normalizedValue": round(seven_day_pct / 100, 4)
+    })
+
+# Build snapshot
 snapshot = {
     "title": "Claude Code",
     "symbol": "staroflife",
-    "metrics": [m for m in [
-        {"title": "Model", "formattedValue": model},
-        pct("Context", ctx),
-        pct("5h", five),
-        pct("7d", seven),
-    ] if m is not None],
+    "metrics": metrics,
     "lastUpdatedDate": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
 }
-if ctx is not None:
-    snapshot["metricsBarValue"] = f"{ctx:g}%"
+
+# Set metrics bar value to 5h rate limit
+if five_hour_pct is not None:
+    snapshot["metricsBarValue"] = f"{five_hour_pct}%"
 
 OUT.parent.mkdir(parents=True, exist_ok=True)
 fd, tmp = tempfile.mkstemp(prefix=".runcat-", dir=str(OUT.parent))


### PR DESCRIPTION
## Context of Contribution

- [ ] Bug Fix
- [ ] Refactoring
- [x] New Feature
- [ ] Others

## Summary of the Proposal

Extends `docs/samples/claude-code/runcat-statusline.py` (and its README) so the 5h/7d rate-limit rows written to `runcat-usage.json` include a reset time, e.g. `69% (~14:30)` or `12% (~7/22 03:00)`.

Recent Claude Code versions include `rate_limits.five_hour.resets_at` / `rate_limits.seven_day.resets_at` (Unix epoch seconds) in the statusLine stdin payload. `plan-usage-history.json` (used for the percentages) doesn't carry reset times at all, so this reads them from the payload instead and appends a formatted `(~HH:MM)` / `(~M/D HH:MM)` suffix. On older CLI versions where `rate_limits` isn't present, the script falls back to a plain percentage with no suffix, so nothing breaks.

## Reason for the new feature

The card previously only showed *how much* of the rate limit was used, with no indication of *when* it resets. Surfacing the reset time directly in the Custom Metrics card (and the statusLine text) lets users plan around their limit without switching to the Claude app.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) and agree to follow it.
- [x] This PR does not contain commits of multiple contexts.
- [x] Code follows proper indentation and naming conventions.
- [x] Implemented using only APIs that can be submitted to the App Store.