### PR TITLE
Add GitHub stats sample integration

### DIFF
--- a/docs/samples/github-stats/README.md
+++ b/docs/samples/github-stats/README.md
@@ -1,0 +1,95 @@
+# GitHub Statistics Integration
+
+A Python script that tracks your GitHub contribution activity in RunCat Neo. Shows your daily commits, weekly progress, contribution streak, and merged PRs at a glance.
+
+## Features
+
+- **Today's commits** - How active you've been today
+- **This week's commits** - Weekly progress with a visual bar
+- **Current streak** - Consecutive days with contributions
+- **Best streak** - Your personal record
+- **PRs merged this week** - Actual shipped work
+
+## Setup
+
+### 1. Install and authenticate GitHub CLI
+
+```bash
+# Install if you haven't already
+brew install gh
+
+# Authenticate (if not already done)
+gh auth login
+```
+
+That's it! The script uses your existing GitHub CLI authentication - no tokens to manage.
+
+### 2. Install the script
+
+```bash
+cp update-github-stats.py ~/.runcat/update-github-stats.py
+chmod +x ~/.runcat/update-github-stats.py
+```
+
+### 3. Test it
+
+```bash
+~/.runcat/update-github-stats.py
+python3 -m json.tool ~/.runcat/github-stats.json
+```
+
+You should see your GitHub stats in the JSON output.
+
+### 4. Set up automatic updates
+
+Copy the launchd configuration:
+
+```bash
+cp dev.runcat.github-stats.plist ~/Library/LaunchAgents/
+launchctl load ~/Library/LaunchAgents/dev.runcat.github-stats.plist
+```
+
+This runs the script:
+- Every 10 minutes (600 seconds)
+- Automatically on login
+- In the background
+
+### 5. Add to RunCat Neo
+
+1. Open **RunCat Neo → Settings → Metrics → Custom Metrics**
+2. Click **"Add JSON Source"**
+3. Select `~/.runcat/github-stats.json`
+4. The card appears on your dashboard immediately
+
+### Optional: Show in Menu Bar
+
+Click the Metrics Bar icon and toggle the GitHub stats source to show your today's commit count directly in the menu bar.
+
+## Customization
+
+Edit the script to adjust:
+- **`metricsBarValue`** - Currently shows today's commits; change to streak or week count
+- **Metric normalization** - Line 197 normalizes weekly commits to max 100; adjust as needed
+- **SF Symbol** - Line 209 uses `chevron.left.forwardslash.chevron.right`; pick any [SF Symbol](https://developer.apple.com/sf-symbols/)
+
+## Troubleshooting
+
+**"Error: GitHub CLI (gh) not found"**
+- Install it with: `brew install gh`
+
+**"Error getting GitHub credentials"**
+- Make sure you're logged in: `gh auth login`
+- Check your auth status: `gh auth status`
+
+**"GitHub API error"**
+- Your GitHub CLI session may have expired - re-authenticate with `gh auth login`
+
+**Card shows old data**
+- Check if the script is running: `launchctl list | grep github-stats`
+- View logs: `log show --predicate 'process == "update-github-stats.py"' --last 1h`
+- Run manually to see errors: `~/.runcat/update-github-stats.py`
+
+**Rate limiting**
+- Authenticated requests get 5,000 requests/hour (plenty for this use case)
+- The script makes 3 GraphQL queries per run
+- Running every 10 minutes = 144 runs/day = 432 API calls/day (well under limit)

--- a/docs/samples/github-stats/dev.runcat.github-stats.plist
+++ b/docs/samples/github-stats/dev.runcat.github-stats.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>dev.runcat.github-stats</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/YOU/.runcat/update-github-stats.py</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>600</integer>
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>

--- a/docs/samples/github-stats/update-github-stats.py
+++ b/docs/samples/github-stats/update-github-stats.py
@@ -98,11 +98,17 @@ def get_contribution_stats():
     """Fetch contribution statistics from GitHub."""
     today = datetime.now(timezone.utc)
     week_start = today - timedelta(days=today.weekday())
+    # Use tomorrow to include all of today's contributions
+    tomorrow = today + timedelta(days=1)
+
+    # Format dates as YYYY-MM-DD with explicit times to avoid partial day issues
+    week_start_str = week_start.strftime("%Y-%m-%d") + "T00:00:00Z"
+    tomorrow_str = tomorrow.strftime("%Y-%m-%d") + "T00:00:00Z"
 
     query = f"""
     {{
       user(login: "{GITHUB_USERNAME}") {{
-        contributionsCollection(from: "{week_start.isoformat()}", to: "{today.isoformat()}") {{
+        contributionsCollection(from: "{week_start_str}", to: "{tomorrow_str}") {{
           contributionCalendar {{
             totalContributions
             weeks {{
@@ -148,11 +154,17 @@ def calculate_streak():
     # Fetch last year of contributions
     today = datetime.now(timezone.utc)
     year_ago = today - timedelta(days=365)
+    # Use tomorrow to include all of today's contributions
+    tomorrow = today + timedelta(days=1)
+
+    # Format dates as YYYY-MM-DD with explicit times to avoid partial day issues
+    year_ago_str = year_ago.strftime("%Y-%m-%d") + "T00:00:00Z"
+    tomorrow_str = tomorrow.strftime("%Y-%m-%d") + "T00:00:00Z"
 
     query = f"""
     {{
       user(login: "{GITHUB_USERNAME}") {{
-        contributionsCollection(from: "{year_ago.isoformat()}", to: "{today.isoformat()}") {{
+        contributionsCollection(from: "{year_ago_str}", to: "{tomorrow_str}") {{
           contributionCalendar {{
             weeks {{
               contributionDays {{
@@ -216,28 +228,102 @@ def get_merged_prs():
     return result["data"]["search"]["issueCount"]
 
 
+def get_recent_days_contributions(days=7):
+    """Get contribution counts for the last N days."""
+    today = datetime.now(timezone.utc)
+    start_date = today - timedelta(days=days - 1)
+    # Use tomorrow to include all of today's contributions
+    tomorrow = today + timedelta(days=1)
+
+    # Format dates as YYYY-MM-DD with explicit times to avoid partial day issues
+    start_date_str = start_date.strftime("%Y-%m-%d") + "T00:00:00Z"
+    tomorrow_str = tomorrow.strftime("%Y-%m-%d") + "T00:00:00Z"
+
+    query = f"""
+    {{
+      user(login: "{GITHUB_USERNAME}") {{
+        contributionsCollection(from: "{start_date_str}", to: "{tomorrow_str}") {{
+          contributionCalendar {{
+            weeks {{
+              contributionDays {{
+                contributionCount
+                date
+              }}
+            }}
+          }}
+        }}
+      }}
+    }}
+    """
+
+    result = github_graphql(query)
+    weeks = result["data"]["user"]["contributionsCollection"]["contributionCalendar"]["weeks"]
+
+    # Flatten all days
+    daily_contributions = []
+    for week in weeks:
+        for day in week["contributionDays"]:
+            daily_contributions.append({
+                "date": day["date"],
+                "count": day["contributionCount"]
+            })
+
+    # Return last N days
+    return daily_contributions[-days:]
+
+
 try:
     stats = get_contribution_stats()
-    current_streak, best_streak = calculate_streak()
-    merged_prs = get_merged_prs()
+    recent_days = get_recent_days_contributions(7)
 
     metrics = [
-        {"title": "Today", "formattedValue": f"{stats['today']} commits"},
-        {
-            "title": "This Week",
-            "formattedValue": f"{stats['week']} commits",
-            "normalizedValue": round(min(stats['week'] / 100, 1.0), 4)  # Normalize to max 100 commits
-        },
+        {"title": "Today", "formattedValue": f"{stats['today']} contributes"},
     ]
 
-    if current_streak > 0:
-        metrics.append({"title": "Streak", "formattedValue": f"{current_streak} days"})
+    # Add today's contribution graph (always shown, even if 0)
+    today = datetime.now(timezone.utc)
+    today_str = today.strftime("%Y-%m-%d")
+    today_date_label = today.strftime("%-m/%-d")
 
-    if best_streak > 0:
-        metrics.append({"title": "Best Streak", "formattedValue": f"{best_streak} days"})
+    max_contributions = max((day["count"] for day in recent_days), default=10)
 
-    if merged_prs > 0:
-        metrics.append({"title": "PRs Merged", "formattedValue": f"{merged_prs} this week"})
+    # Add today's graph
+    today_count = stats['today']
+    today_normalized = min(today_count / max(max_contributions, 10), 1.0) if today_count > 0 else 0
+    metrics.append({
+        "title": f"{today_date_label} (today)",
+        "formattedValue": str(today_count),
+        "normalizedValue": round(today_normalized, 4)
+    })
+
+    # Add recent 2 days with contributions (excluding today)
+    daily_metrics = []
+    for day_data in reversed(recent_days):
+        if day_data["date"] == today_str:
+            continue  # Skip today, already added
+
+        count = day_data["count"]
+        if count > 0:
+            date_obj = datetime.fromisoformat(day_data["date"].replace('Z', '+00:00'))
+            date_label = date_obj.strftime("%-m/%-d") if hasattr(date_obj, 'strftime') else day_data["date"][-5:]
+
+            # Normalize based on max contributions in the period
+            normalized = min(count / max(max_contributions, 10), 1.0)
+            daily_metrics.append({
+                "title": date_label,
+                "formattedValue": str(count),
+                "normalizedValue": round(normalized, 4)
+            })
+
+    # Add only the last 2 days with contributions (excluding today)
+    metrics.extend(daily_metrics[:2])
+
+    # Add weekly total at the bottom
+    metrics.append({
+        "title": "This Week",
+        "formattedValue": str(stats['week']),
+        "normalizedValue": round(min(stats['week'] / 100, 1.0), 4)  # Normalize to max 100 commits
+    })
 
     snapshot = {
         "title": "GitHub",
@@ -253,7 +339,7 @@ try:
         json.dump(snapshot, f, ensure_ascii=False, indent=2)
     os.replace(tmp, OUT)
 
-    print(f"✓ GitHub stats updated: {stats['today']} commits today, {current_streak} day streak")
+    print(f"✓ GitHub stats updated: {stats['today']} commits today, {stats['week']} this week")
 
 except Exception as e:
     print(f"Error: {e}", file=sys.stderr)

--- a/docs/samples/github-stats/update-github-stats.py
+++ b/docs/samples/github-stats/update-github-stats.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""
+RunCat Neo — GitHub Statistics sample.
+
+Fetches GitHub contribution stats and writes ~/.runcat/github-stats.json shaped like:
+
+    {
+      "title": "GitHub",
+      "symbol": "chevron.left.forwardslash.chevron.right",
+      "metricsBarValue": "5",
+      "metrics": [
+        {"title": "Today", "formattedValue": "5 commits"},
+        {"title": "This Week", "formattedValue": "23 commits", "normalizedValue": 0.23},
+        {"title": "Streak", "formattedValue": "42 days"},
+        {"title": "Best Streak", "formattedValue": "128 days"},
+        {"title": "PRs Merged", "formattedValue": "3 this week"}
+      ],
+      "lastUpdatedDate": "2026-07-18T09:30:00Z"
+    }
+
+Setup:
+1. Install GitHub CLI if you haven't already:
+   brew install gh
+
+2. Authenticate with GitHub:
+   gh auth login
+
+3. Run the script manually to test:
+   ./update-github-stats.py
+
+4. Set up periodic execution (see launchd plist example)
+
+The script automatically uses your GitHub CLI authentication - no tokens to manage!
+"""
+
+import json
+import os
+import sys
+import subprocess
+import tempfile
+import urllib.request
+import urllib.error
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+OUT = Path(os.environ.get("RUNCAT_OUT_FILE", str(Path.home() / ".runcat" / "github-stats.json")))
+
+
+def run_gh_command(args):
+    """Run a gh command and return its output."""
+    try:
+        result = subprocess.run(
+            ["gh"] + args,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=15
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        print(f"gh command failed: {e.stderr}", file=sys.stderr)
+        sys.exit(1)
+    except FileNotFoundError:
+        print("Error: GitHub CLI (gh) not found. Install it with: brew install gh", file=sys.stderr)
+        sys.exit(1)
+
+
+# Get token and username from GitHub CLI
+try:
+    GITHUB_TOKEN = run_gh_command(["auth", "token"])
+    user_json = run_gh_command(["api", "user"])
+    GITHUB_USERNAME = json.loads(user_json)["login"]
+except Exception as e:
+    print(f"Error getting GitHub credentials: {e}", file=sys.stderr)
+    print("Make sure you're logged in with: gh auth login", file=sys.stderr)
+    sys.exit(1)
+
+
+def github_graphql(query):
+    """Execute a GitHub GraphQL query."""
+    url = "https://api.github.com/graphql"
+    headers = {
+        "Authorization": f"Bearer {GITHUB_TOKEN}",
+        "Content-Type": "application/json",
+    }
+    data = json.dumps({"query": query}).encode("utf-8")
+
+    req = urllib.request.Request(url, data=data, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=15) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.URLError as e:
+        print(f"GitHub API error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def get_contribution_stats():
+    """Fetch contribution statistics from GitHub."""
+    today = datetime.now(timezone.utc)
+    week_start = today - timedelta(days=today.weekday())
+
+    query = f"""
+    {{
+      user(login: "{GITHUB_USERNAME}") {{
+        contributionsCollection(from: "{week_start.isoformat()}", to: "{today.isoformat()}") {{
+          contributionCalendar {{
+            totalContributions
+            weeks {{
+              contributionDays {{
+                contributionCount
+                date
+              }}
+            }}
+          }}
+        }}
+      }}
+    }}
+    """
+
+    result = github_graphql(query)
+
+    if "errors" in result:
+        print(f"GraphQL errors: {result['errors']}", file=sys.stderr)
+        sys.exit(1)
+
+    user = result["data"]["user"]
+    week_data = user["contributionsCollection"]["contributionCalendar"]
+
+    # Calculate today's contributions
+    today_str = today.strftime("%Y-%m-%d")
+    today_contributions = 0
+    week_contributions = 0
+
+    for week in week_data["weeks"]:
+        for day in week["contributionDays"]:
+            week_contributions += day["contributionCount"]
+            if day["date"] == today_str:
+                today_contributions = day["contributionCount"]
+
+    return {
+        "today": today_contributions,
+        "week": week_contributions,
+    }
+
+
+def calculate_streak():
+    """Calculate current and best streak from all-time contributions."""
+    # Fetch last year of contributions
+    today = datetime.now(timezone.utc)
+    year_ago = today - timedelta(days=365)
+
+    query = f"""
+    {{
+      user(login: "{GITHUB_USERNAME}") {{
+        contributionsCollection(from: "{year_ago.isoformat()}", to: "{today.isoformat()}") {{
+          contributionCalendar {{
+            weeks {{
+              contributionDays {{
+                contributionCount
+                date
+              }}
+            }}
+          }}
+        }}
+      }}
+    }}
+    """
+
+    result = github_graphql(query)
+    weeks = result["data"]["user"]["contributionsCollection"]["contributionCalendar"]["weeks"]
+
+    # Flatten all days
+    days = []
+    for week in weeks:
+        for day in week["contributionDays"]:
+            days.append(day)
+
+    # Sort by date descending (newest first)
+    days.sort(key=lambda d: d["date"], reverse=True)
+
+    # Calculate current streak
+    current_streak = 0
+    for day in days:
+        if day["contributionCount"] > 0:
+            current_streak += 1
+        else:
+            break
+
+    # Calculate best streak
+    best_streak = 0
+    temp_streak = 0
+    for day in reversed(days):  # Process chronologically for best streak
+        if day["contributionCount"] > 0:
+            temp_streak += 1
+            best_streak = max(best_streak, temp_streak)
+        else:
+            temp_streak = 0
+
+    return current_streak, max(best_streak, current_streak)
+
+
+def get_merged_prs():
+    """Get count of merged PRs this week."""
+    today = datetime.now(timezone.utc)
+    week_start = today - timedelta(days=today.weekday())
+
+    query = f"""
+    {{
+      search(query: "author:{GITHUB_USERNAME} is:pr is:merged merged:>={week_start.strftime('%Y-%m-%d')}", type: ISSUE, first: 100) {{
+        issueCount
+      }}
+    }}
+    """
+
+    result = github_graphql(query)
+    return result["data"]["search"]["issueCount"]
+
+
+try:
+    stats = get_contribution_stats()
+    current_streak, best_streak = calculate_streak()
+    merged_prs = get_merged_prs()
+
+    metrics = [
+        {"title": "Today", "formattedValue": f"{stats['today']} commits"},
+        {
+            "title": "This Week",
+            "formattedValue": f"{stats['week']} commits",
+            "normalizedValue": round(min(stats['week'] / 100, 1.0), 4)  # Normalize to max 100 commits
+        },
+    ]
+
+    if current_streak > 0:
+        metrics.append({"title": "Streak", "formattedValue": f"{current_streak} days"})
+
+    if best_streak > 0:
+        metrics.append({"title": "Best Streak", "formattedValue": f"{best_streak} days"})
+
+    if merged_prs > 0:
+        metrics.append({"title": "PRs Merged", "formattedValue": f"{merged_prs} this week"})
+
+    snapshot = {
+        "title": "GitHub",
+        "symbol": "chevron.left.forwardslash.chevron.right",
+        "metricsBarValue": str(stats['today']),
+        "metrics": metrics,
+        "lastUpdatedDate": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=".github-stats-", dir=str(OUT.parent))
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        json.dump(snapshot, f, ensure_ascii=False, indent=2)
+    os.replace(tmp, OUT)
+
+    print(f"✓ GitHub stats updated: {stats['today']} commits today, {current_streak} day streak")
+
+except Exception as e:
+    print(f"Error: {e}", file=sys.stderr)
+    sys.exit(1)


### PR DESCRIPTION
## Context of Contribution

- [ ] Bug Fix
- [ ] Refactoring
- [x] New Feature
- [ ] Others

## Summary of the Proposal

Adds a new `docs/samples/github-stats/` integration:

- `update-github-stats.py` — polls the GitHub API and writes a Custom Metrics JSON snapshot showing contribution counts (today, last 2 active days, this week), correctly including private-repo contributions.
- `dev.runcat.github-stats.plist` — launchd config to run the script on a schedule.
- `README.md` — setup and usage instructions, following the same format as the other `docs/samples/` entries.

## Reason for the new feature

`docs/samples/` already showcases Claude Code, Codex, and Bitcoin-price integrations with RunCat Neo's Custom Metrics card. GitHub contribution activity is a natural addition for the same audience (developers who already have RunCat Neo running) and follows the existing sample format, so it's low-cost to maintain and adds another concrete example for users building their own integrations.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) and agree to follow it.
- [x] This PR does not contain commits of multiple contexts.
- [x] Code follows proper indentation and naming conventions.
- [x] Implemented using only APIs that can be submitted to the App Store.