### PR TITLE
Add rate-limit reset time to Claude Code statusline sample

### DIFF
--- a/docs/samples/claude-code/runcat-statusline.py
+++ b/docs/samples/claude-code/runcat-statusline.py
@@ -11,8 +11,8 @@ Writes ~/.claude/runcat-usage.json shaped like:
       "metrics": [
         {"title": "Model",   "formattedValue": "Opus 4.7"},
         {"title": "Context", "formattedValue": "67%", "normalizedValue": 0.67},
-        {"title": "5h",      "formattedValue": "3%",  "normalizedValue": 0.03},
-        {"title": "7d",      "formattedValue": "3%",  "normalizedValue": 0.03}
+        {"title": "5h",      "formattedValue": "3% (~14:30)",  "normalizedValue": 0.03},
+        {"title": "7d",      "formattedValue": "3% (~7/22 03:00)",  "normalizedValue": 0.03}
       ],
       "lastUpdatedDate": "2026-06-07T05:55:36Z"
     }
@@ -28,10 +28,22 @@ from pathlib import Path
 OUT = Path(os.environ.get("RUNCAT_OUT_FILE", str(Path.home() / ".claude" / "runcat-usage.json")))
 
 
-def pct(title, value):
+def pct(title, value, reset=None):
     if value is None:
         return None
-    return {"title": title, "formattedValue": f"{value:g}%", "normalizedValue": round(value / 100, 4)}
+    formatted = f"{value:g}%" + (f" ({reset})" if reset else "")
+    return {"title": title, "formattedValue": formatted, "normalizedValue": round(value / 100, 4)}
+
+
+def format_reset(epoch_seconds):
+    if epoch_seconds is None:
+        return None
+    now = datetime.now().astimezone()
+    reset = datetime.fromtimestamp(epoch_seconds).astimezone()
+    hm = reset.strftime("%H:%M")
+    if reset.date() == now.date():
+        return f"~{hm}"
+    return f"~{reset.month}/{reset.day} {hm}"
 
 
 try:
@@ -46,6 +58,8 @@ ctx = (payload.get("context_window") or {}).get("used_percentage")
 rate_limits = payload.get("rate_limits") or {}
 five = (rate_limits.get("five_hour") or {}).get("used_percentage")
 seven = (rate_limits.get("seven_day") or {}).get("used_percentage")
+five_reset = format_reset((rate_limits.get("five_hour") or {}).get("resets_at"))
+seven_reset = format_reset((rate_limits.get("seven_day") or {}).get("resets_at"))
 
 snapshot = {
     "title": "Claude Code",
@@ -53,8 +67,8 @@ snapshot = {
     "metrics": [m for m in [
         {"title": "Model", "formattedValue": model},
         pct("Context", ctx),
-        pct("5h", five),
-        pct("7d", seven),
+        pct("5h", five, five_reset),
+        pct("7d", seven, seven_reset),
     ] if m is not None],
     "lastUpdatedDate": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
 }


### PR DESCRIPTION
## Context of Contribution

- [ ] Bug Fix
- [ ] Refactoring
- [x] New Feature
- [ ] Others

## Summary of the Proposal

As mentioned in #56, this is a cleaned-up resubmission of the rate-limit
reset time feature, rebuilt from scratch as a minimal diff on top of the
latest `main` per your feedback.

Extends `docs/samples/claude-code/runcat-statusline.py` so the 5h/7d
rate-limit metrics written to `runcat-usage.json` include a reset time,
e.g. `3% (~14:30)` or `12% (~7/22 03:00)`.

Recent Claude Code versions include `rate_limits.five_hour.resets_at` /
`rate_limits.seven_day.resets_at` (Unix epoch seconds) in the statusLine
stdin payload, alongside the `used_percentage` fields the script already
reads. This formats that timestamp as `~HH:MM` for a same-day reset, or
`~M/D HH:MM` otherwise, and appends it to the existing 5h/7d values.

No new file reads, no new dependencies, and no requirement for the Claude
Desktop App — everything comes from the same JSON payload the script
already parses on stdin.

On older CLI versions (or plans where `rate_limits` isn't populated),
`resets_at` is simply absent and the script falls back to a plain
percentage, same as before.

## Screenshot

The Custom Metrics card showing both formats: the 5h row with a same-day
reset (`~HH:MM`) and the 7d row with a cross-day reset (`~M/D HH:MM`).

<img width="256" height="324" alt="スクリーンショット 2026-07-19 19 08 22" src="https://github.com/user-attachments/assets/a05f30b1-8983-4335-9104-cf60c89f5ea9" />


## Reference

The reset-time display rule (same-day → `~HH:MM`, cross-day →
`~M/D HH:MM`) follows the approach described in [Brainy-Software's Zenn
article on displaying Claude Code's rate-limit reset time](https://zenn.dev/brainy_software/articles/claude-code-statusline-reset-time)
(the article implements it in JavaScript; this PR applies the same
formatting rule in Python).

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) and agree to follow it.
- [x] This PR does not contain commits of multiple contexts.
- [x] Code follows proper indentation and naming conventions.
- [x] Implemented using only APIs that can be submitted to the App Store.

Base branch: runcat-dev/RunCatNeo:main ← Masahide-S/RunCatNeo:feature/rate-limit-reset