### PR TITLE
Add configurable Codex Metrics Bar value

### DIFF
--- a/docs/samples/codex/README.md
+++ b/docs/samples/codex/README.md
@@ -33,7 +33,7 @@ This sample uses Codex's local session transcript, whose format may change betwe
 3. Restart Codex, then use `/hooks` to review and trust the new hook if prompted.
 4. Complete a turn in Codex. The script creates `~/.codex/runcat-usage.json` after the turn finishes.
 5. In RunCat Neo, open **Settings → Metrics → Custom Metrics**, click **Add JSON Source**, and choose `~/.codex/runcat-usage.json`.
-6. Optional: click the Metrics Bar and flip the source's toggle to show the context usage directly in the menu bar.
+6. Optional: click the Metrics Bar and flip the source's toggle to show its value in the menu bar. The default value is the remaining 7-day allowance, such as `7d 77%`.
 
 The hook feature is enabled by default in current Codex releases. If `/hooks` is unavailable, add this to `~/.codex/config.toml` and restart Codex:
 
@@ -46,9 +46,26 @@ hooks = true
 
 - **Model** — the active model slug provided to the hook.
 - **Context** — the latest context token count divided by the model's context-window size.
-- **5h**, **7d**, or another duration — each rate-limit window included in the latest token-count event.
+- **5h**, **7d**, or another duration — the used percentage for each rate-limit window included in the latest token-count event.
+- **Metrics Bar** — the remaining 7-day allowance by default. For example, a `7d` row showing `23%` used produces `7d 77%` in the menu bar.
 
 If a snapshot already exists, sessions without a recognized token-count event or account rate limits leave the last valid snapshot untouched. This prevents concurrent API-key, local-model, or incomplete sessions from replacing account usage with a Model-only card. The script always exits successfully so a parsing failure does not interrupt Codex.
+
+## Choose the Metrics Bar value
+
+RunCat Neo's toggle controls whether the Custom Metrics source is visible in the Metrics Bar; it does not select one of the card's rows. This sample therefore reads the desired value from `~/.codex/runcat-bar-mode`:
+
+```bash
+# Show the remaining 7-day allowance (default).
+printf 'weekly\n' > ~/.codex/runcat-bar-mode
+
+# Show context-window usage instead.
+printf 'context\n' > ~/.codex/runcat-bar-mode
+```
+
+The change appears after the next completed Codex turn. If the selected metric is unavailable, the script falls back to the other value so the Metrics Bar does not show `---`.
+
+`RUNCAT_BAR_MODE` overrides the file with `weekly` or `context` for one invocation. `RUNCAT_BAR_MODE_FILE` overrides the mode file path.
 
 ## Customizing the output
 

--- a/docs/samples/codex/README.md
+++ b/docs/samples/codex/README.md
@@ -33,7 +33,7 @@ This sample uses Codex's local session transcript, whose format may change betwe
 3. Restart Codex, then use `/hooks` to review and trust the new hook if prompted.
 4. Complete a turn in Codex. The script creates `~/.codex/runcat-usage.json` after the turn finishes.
 5. In RunCat Neo, open **Settings → Metrics → Custom Metrics**, click **Add JSON Source**, and choose `~/.codex/runcat-usage.json`.
-6. Optional: click the Metrics Bar and flip the source's toggle to show its value in the menu bar. The default value is the remaining 7-day allowance, such as `7d 77%`.
+6. Optional: click the Metrics Bar and flip the source's toggle to show context usage in the menu bar.
 
 The hook feature is enabled by default in current Codex releases. If `/hooks` is unavailable, add this to `~/.codex/config.toml` and restart Codex:
 
@@ -47,19 +47,23 @@ hooks = true
 - **Model** — the active model slug provided to the hook.
 - **Context** — the latest context token count divided by the model's context-window size.
 - **5h**, **7d**, or another duration — the used percentage for each rate-limit window included in the latest token-count event.
-- **Metrics Bar** — the remaining 7-day allowance by default. For example, a `7d` row showing `23%` used produces `7d 77%` in the menu bar.
+- **Metrics Bar** — context-window usage by default. Weekly mode shows the remaining 7-day allowance; for example, a `7d` row showing `23%` used produces `7d 77%` in the menu bar.
 
 If a snapshot already exists, sessions without a recognized token-count event or account rate limits leave the last valid snapshot untouched. This prevents concurrent API-key, local-model, or incomplete sessions from replacing account usage with a Model-only card. The script always exits successfully so a parsing failure does not interrupt Codex.
 
 ## Choose the Metrics Bar value
 
-RunCat Neo's toggle controls whether the Custom Metrics source is visible in the Metrics Bar; it does not select one of the card's rows. This sample therefore reads the desired value from `~/.codex/runcat-bar-mode`:
+RunCat Neo's toggle controls whether the Custom Metrics source is visible in the Metrics Bar; it does not select one of the card's rows. Context usage remains the default for compatibility.
+
+To show the remaining 7-day allowance instead, create `~/.codex/runcat-bar-mode` with `weekly` as its content:
 
 ```bash
-# Show the remaining 7-day allowance (default).
 printf 'weekly\n' > ~/.codex/runcat-bar-mode
+```
 
-# Show context-window usage instead.
+The mode file is optional and is not created automatically. If it is missing or invalid, the script uses `context`. You can also select that mode explicitly:
+
+```bash
 printf 'context\n' > ~/.codex/runcat-bar-mode
 ```
 

--- a/docs/samples/codex/runcat-hook.py
+++ b/docs/samples/codex/runcat-hook.py
@@ -101,7 +101,7 @@ def bar_mode():
             mode = BAR_MODE_FILE.read_text(encoding="utf-8").strip().lower()
         except OSError:
             mode = ""
-    return mode if mode in {"context", "weekly"} else "weekly"
+    return mode if mode in {"context", "weekly"} else "context"
 
 
 def metrics_bar_value(token_count, context):

--- a/docs/samples/codex/runcat-hook.py
+++ b/docs/samples/codex/runcat-hook.py
@@ -10,6 +10,9 @@ from pathlib import Path
 
 
 OUT = Path(os.environ.get("RUNCAT_OUT_FILE", str(Path.home() / ".codex" / "runcat-usage.json")))
+BAR_MODE_FILE = Path(
+    os.environ.get("RUNCAT_BAR_MODE_FILE", str(Path.home() / ".codex" / "runcat-bar-mode"))
+)
 
 
 def percentage_metric(title, used_percentage):
@@ -79,6 +82,43 @@ def rate_limit_metrics(token_count):
     return metrics
 
 
+def weekly_remaining_metric(token_count):
+    rate_limits = (token_count or {}).get("rate_limits") or {}
+    for key in ("primary", "secondary"):
+        limit = rate_limits.get(key) or {}
+        if window_title(limit.get("window_minutes")) != "7d":
+            continue
+        used_percentage = limit.get("used_percent")
+        if isinstance(used_percentage, (int, float)):
+            return percentage_metric("7d Left", 100 - used_percentage)
+    return None
+
+
+def bar_mode():
+    mode = os.environ.get("RUNCAT_BAR_MODE", "").strip().lower()
+    if not mode:
+        try:
+            mode = BAR_MODE_FILE.read_text(encoding="utf-8").strip().lower()
+        except OSError:
+            mode = ""
+    return mode if mode in {"context", "weekly"} else "weekly"
+
+
+def metrics_bar_value(token_count, context):
+    weekly = weekly_remaining_metric(token_count)
+    if bar_mode() == "context":
+        if context is not None:
+            return context["formattedValue"]
+        if weekly is not None:
+            return f"7d {weekly['formattedValue']}"
+    else:
+        if weekly is not None:
+            return f"7d {weekly['formattedValue']}"
+        if context is not None:
+            return context["formattedValue"]
+    return None
+
+
 def write_snapshot(hook_input):
     model = hook_input.get("model")
     if isinstance(model, str):
@@ -102,8 +142,9 @@ def write_snapshot(hook_input):
         "metrics": metrics,
         "lastUpdatedDate": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
-    if context is not None:
-        snapshot["metricsBarValue"] = context["formattedValue"]
+    bar_value = metrics_bar_value(token_count, context)
+    if bar_value is not None:
+        snapshot["metricsBarValue"] = bar_value
     OUT.parent.mkdir(parents=True, exist_ok=True)
     file_descriptor, temporary_path = tempfile.mkstemp(prefix=".runcat-", dir=str(OUT.parent))
     try:


### PR DESCRIPTION
## Context of Contribution

- [ ] Bug Fix
- [ ] Refactoring
- [x] New Feature
- [ ] Others

## Summary of the Proposal

The Codex integration sample currently always uses context-window usage for `metricsBarValue`, even though the same snapshot also includes account rate-limit data.

This change makes the Metrics Bar value configurable while preserving the existing context-based default and a single Custom Metrics source.

- Keeps context-window usage as the default for compatibility
- Supports the remaining 7-day allowance through an optional `~/.codex/runcat-bar-mode` file
- Does not create the mode file automatically
- Uses `context` when the mode file is missing or invalid
- Supports `RUNCAT_BAR_MODE` and `RUNCAT_BAR_MODE_FILE` overrides
- Falls back to the available metric when the selected value is unavailable
- Documents the difference between card rows and the Metrics Bar value

Validation:

```text
Python syntax compilation — passed
Missing mode file produced the context value with Model, Context, and 7d rows — passed
Weekly mode produced "7d 76%" with the same rows — passed
Git diff whitespace validation — passed
```

## Reason for the new feature

Some Codex users want to monitor their remaining weekly account allowance rather than the context usage of the current conversation.

RunCat Neo's Custom Metrics toggle controls whether a source is visible in the Metrics Bar, while each source exposes a single `metricsBarValue`. An optional producer-side setting provides both choices without changing the existing default, creating duplicate cards, or modifying the JSON schema.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) and agree to follow it.
- [x] This PR does not contain commits of multiple contexts.
- [x] Code follows proper indentation and naming conventions.
- [x] Implemented using only APIs that can be submitted to the App Store.
