### PR TITLE
Fix custom metrics sample doc inconsistencies

### DIFF
--- a/docs/CustomMetricsSchema.md
+++ b/docs/CustomMetricsSchema.md
@@ -84,7 +84,7 @@ There is no minimum cadence. Update the file every second, or only when somethin
 
 See `docs/samples/` for working scripts:
 
-- `docs/samples/claude-code/` — Claude Code statusLine integration that writes context-window and cost rows.
+- `docs/samples/claude-code/` — Claude Code statusLine integration that writes model, context-window, and rate-limit rows.
 - `docs/samples/codex/` — Codex lifecycle hook that writes model, context-window, and rate-limit rows.
 - `docs/samples/bitcoin/` — launchd-scheduled shell script that shows the current Bitcoin price in USD via the CoinGecko public API.
 

--- a/docs/samples/bitcoin/README.md
+++ b/docs/samples/bitcoin/README.md
@@ -28,7 +28,7 @@ Unlike the Claude Code sample, nothing triggers the script for you, so this samp
    ```bash
    launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/dev.runcat.bitcoin-sample.plist
    ```
-4. In RunCat Neo, open **Settings → Metrics → Custom Metrics**, click **Add JSON Source**, and choose `~/.runcat/bitcoin.json`. The folder is hidden in the open panel — press `⌘⇧.` or `⌘⇧G` and type the path. The card appears on the dashboard immediately.
+4. In RunCat Neo, open **Settings → Metrics → Custom Metrics**, click **Add Custom Metrics Source**, and choose `~/.runcat/bitcoin.json`. The folder is hidden in the open panel — press `⌘⇧.` or `⌘⇧G` and type the path. The card appears on the dashboard immediately.
 5. Optional: click the Metrics Bar and flip the source's toggle to show the price (`metricsBarValue`, e.g. `$61.9K`) directly in the menu bar.
 
 To stop updating, unload the agent:

--- a/docs/samples/claude-code/README.md
+++ b/docs/samples/claude-code/README.md
@@ -19,7 +19,7 @@ A minimal Python script that lets RunCat Neo's Custom Metrics card show your Cla
    }
    ```
    Replace `/Users/YOU` with your home path. The shebang at the top of the script picks up `python3` automatically.
-3. In RunCat Neo, open **Settings → Metrics → Custom Metrics**, click **Add JSON Source**, and choose `~/.claude/runcat-usage.json`. The card appears on the dashboard immediately.
+3. In RunCat Neo, open **Settings → Metrics → Custom Metrics**, click **Add Custom Metrics Source**, and choose `~/.claude/runcat-usage.json`. The card appears on the dashboard immediately.
 4. Run Claude Code. The card updates each turn.
 5. Optional: click the Metrics Bar and flip the source's toggle to show the context usage (`metricsBarValue`) directly in the menu bar.
 

--- a/docs/samples/codex/README.md
+++ b/docs/samples/codex/README.md
@@ -32,7 +32,7 @@ This sample uses Codex's local session transcript, whose format may change betwe
    Replace `/Users/YOU` with your home path. If you already have `~/.codex/hooks.json`, add the inner entry to its existing `Stop` array instead of replacing the file.
 3. Restart Codex, then use `/hooks` to review and trust the new hook if prompted.
 4. Complete a turn in Codex. The script creates `~/.codex/runcat-usage.json` after the turn finishes.
-5. In RunCat Neo, open **Settings → Metrics → Custom Metrics**, click **Add JSON Source**, and choose `~/.codex/runcat-usage.json`.
+5. In RunCat Neo, open **Settings → Metrics → Custom Metrics**, click **Add Custom Metrics Source**, and choose `~/.codex/runcat-usage.json`.
 6. Optional: click the Metrics Bar and flip the source's toggle to show the context usage directly in the menu bar.
 
 The hook feature is enabled by default in current Codex releases. If `/hooks` is unavailable, add this to `~/.codex/config.toml` and restart Codex:


### PR DESCRIPTION
## Summary
- Sample READMEs (`bitcoin`, `claude-code`, `codex`) referenced a button called **Add JSON Source**, but the actual UI (`Localizable.xcstrings` → `addCustomMetricsSource`) is **Add Custom Metrics Source**. `docs/CustomMetricsSchema.md` already used the correct label; the READMEs are now aligned.
- `docs/CustomMetricsSchema.md` described the Claude Code sample as writing "context-window and cost rows", but the script writes Model / Context / 5h / 7d (rate-limit) rows — no cost. Rewrote the summary to match the script.

## Test plan
- [x] `git diff` reviewed — docs-only, four one-line edits.
- [ ] Skimmed rendered Markdown on GitHub after the PR opens.