### PR TITLE
Refresh contributor policies and split out ARCHITECTURE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        We do not accept issues in languages other than English.
+        English only. One issue per bug — file related-but-distinct bugs separately. See [CONTRIBUTING.md](https://github.com/runcat-dev/RunCatNeo/blob/main/CONTRIBUTING.md).
 
   - type: input
     id: app-version
@@ -33,7 +33,6 @@ body:
     id: bug-description
     attributes:
       label: "Describe the bug"
-      description: "A clear and concise description of what the bug is."
     validations:
       required: true
 
@@ -41,7 +40,6 @@ body:
     id: steps-to-reproduce
     attributes:
       label: "How to reproduce"
-      description: "Steps to reproduce the bug."
       value: |
         1.
         2.
@@ -54,15 +52,13 @@ body:
     id: expected-behavior
     attributes:
       label: "Expected behavior"
-      description: "A description of what you expected to happen."
     validations:
       required: true
 
   - type: textarea
     id: screenshots
     attributes:
-      label: "Screenshots"
-      description: "If possible, attach screenshots."
+      label: "Screenshots (optional)"
     validations:
       required: false
 
@@ -71,11 +67,9 @@ body:
     attributes:
       label: "Check List"
       options:
-        - label: "I have read the [CONTRIBUTING.md](https://github.com/runcat-dev/RunCatNeo/blob/main/CONTRIBUTING.md) and agree to follow it."
+        - label: "I have read [CONTRIBUTING.md](https://github.com/runcat-dev/RunCatNeo/blob/main/CONTRIBUTING.md)."
           required: true
-        - label: "Uninstalled App."
+        - label: "I reinstalled the app, rebooted my Mac, and the bug still reproduces."
           required: true
-        - label: "Re-launched your computer."
-          required: true
-        - label: "Checked that no similar issues already exist."
+        - label: "No duplicate exists. I will file any related-but-distinct bugs as separate issues."
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,31 +6,29 @@ body:
   - type: markdown
     attributes:
       value: |
-        We do not accept requests in languages other than English.
-        Requests to add new runners are not accepted here.
-        Custom runners are distributed in the [Runner Gallery](https://runcat-dev.github.io/RunnerGallery/) — please make your request there.
+        English only. Runner requests → [Runner Gallery](https://runcat-dev.github.io/RunnerGallery/) (not here). New UI languages ARE welcome here.
+
+        Skim [CONTRIBUTING.md](https://github.com/runcat-dev/RunCatNeo/blob/main/CONTRIBUTING.md) first — it defines the acceptance bar (benefit must outweigh maintenance cost) and the one-issue-per-topic rule.
 
   - type: textarea
     id: overview
     attributes:
       label: "Overview of the requested feature"
-      description: "Please provide a brief summary of the feature you're requesting."
     validations:
       required: true
 
   - type: textarea
     id: reason
     attributes:
-      label: "Reason for the request"
-      description: "Explain why this feature is needed and what motivated your request."
+      label: "Why this feature is worth the maintenance cost"
+      description: "Who benefits, how broadly, and why the benefit outweighs the ongoing cost of shipping and maintaining it."
     validations:
       required: true
 
   - type: textarea
     id: related-issues
     attributes:
-      label: "Related Issues"
-      description: "Link to related issues, if applicable."
+      label: "Related Issues (optional)"
     validations:
       required: false
 
@@ -39,11 +37,11 @@ body:
     attributes:
       label: "Check List"
       options:
-        - label: "I have read the [CONTRIBUTING.md](https://github.com/runcat-dev/RunCatNeo/blob/main/CONTRIBUTING.md) and agree to follow it."
+        - label: "I have read [CONTRIBUTING.md](https://github.com/runcat-dev/RunCatNeo/blob/main/CONTRIBUTING.md)."
           required: true
-        - label: "The proposed feature is beneficial to a wide range of users and not just a personal preference."
+        - label: "This benefits a wide range of users, and its benefit clearly outweighs the ongoing maintenance cost."
           required: true
-        - label: "This is not a request to add a new runner. Runner requests belong in the [Runner Gallery](https://runcat-dev.github.io/RunnerGallery/)."
+        - label: "Not a runner request (those go to the [Runner Gallery](https://runcat-dev.github.io/RunnerGallery/))."
           required: true
-        - label: "Checked that no similar requests already exist."
+        - label: "No duplicate exists. I will file any similar-but-distinct ideas as separate issues rather than stacking them here."
           required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,7 @@
 - [ ] Bug Fix
 - [ ] Refactoring
 - [ ] New Feature
+- [ ] Localization (new language or translation update)
 - [ ] Others
 
 ## Summary of the Proposal
@@ -22,5 +23,8 @@
 
 - [ ] I have read the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) and agree to follow it.
 - [ ] This PR does not contain commits of multiple contexts.
+- [ ] The diff is minimal — no unrelated refactors, whitespace churn, or drive-by cleanups.
 - [ ] Code follows proper indentation and naming conventions.
+- [ ] Layering follows the [LUCA architecture](../blob/main/ARCHITECTURE.md): no logic in `DependencyClient`, no logic in `UserInterface` views, no Asset/String Catalog references from `Model`.
 - [ ] Implemented using only APIs that can be submitted to the App Store.
+- [ ] **Localization PRs only:** Every translated string in this PR was hand-crafted by a human translator. No machine translation or LLM output was used. See [CONTRIBUTING.md → Localization](../blob/main/CONTRIBUTING.md#localization).

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,57 @@
+# Architecture
+
+RunCat Neo follows the [LUCA architecture](https://github.com/Kyome22/LUCA). All source lives in the `LocalPackage/` Swift Package under three library targets with a strict, one-way dependency direction:
+
+```
+UserInterface  →  Model  →  DataSource
+```
+
+Arrows show the direction of `import`. `UserInterface` may import `Model` and `DataSource`; `Model` may import `DataSource`; `DataSource` imports nothing from the other two. **Never invert this direction.**
+
+## Layer Responsibilities
+
+- **`DataSource`** — leaf layer. Holds:
+  - `Entities` — plain `Sendable` values (`AppState`, `Metrics`, `Runner`, `AsyncStreamBundle`, etc.)
+  - `Dependencies` — thin `Sendable` wrappers around system APIs (`UserDefaults`, `NSWorkspace`, `FileManager`, `SMAppService`, etc.), each conforming to `DependencyClient` with `liveValue` + `testValue`
+  - `Repositories` — composed of dependencies
+  - No application logic.
+
+- **`Model`** — depends on `DataSource`. Holds:
+  - `Services` — long-lived workers wired in `AppDelegate` (`MetricsService`, `RunnerService`, `LogService`)
+  - `Stores` — `@MainActor @Observable` view-models conforming to `Composable` (`Dashboard`, `RunnerBar`, `MetricsBar`, settings stores)
+  - `AppDependencies` — the bag of all dependency clients, injected everywhere via the `\.appDependencies` SwiftUI environment value
+  - `AppDelegate`
+  - **This is where application logic lives.**
+
+- **`UserInterface`** — depends on `DataSource` + `Model`. Holds:
+  - SwiftUI `Scenes` (`RunnerBarScene`, `MetricsBarScene`, `SettingsWindowScene`)
+  - SwiftUI `Views`
+  - Localized strings and image assets in `UserInterface/Resources/`
+  - **No logic.**
+
+## DependencyClient
+
+`DependencyClient` conformances exist so tests can inject overrides via `testDependency(of:injection:)`. Treat them as thin, untested boundaries — nothing more.
+
+- **Never put logic inside a `DependencyClient`.** Clients themselves are never covered by tests. Any conditional, error-handling branch, retry, or state coordination written inside a client is behaviorally unverified — it silently degrades the test guarantees the rest of the codebase relies on.
+- A client method should be **one direct call into the underlying system API**, wrapping the result into `Sendable` values where necessary. Anything more sits in a `Service` or `Store`, which are covered by tests.
+- Use `DependencyClient` **only as a spot-mock window for effects the project does not control** — `UserDefaults`, `FileManager`, `NSWorkspace`, `SMAppService`, networking, notifications, and similar system-owned side effects. If a piece of code does not need to be swapped in tests, it does not belong in a client.
+
+## Stores and the Composable pattern
+
+Stores implement `Composable`: they expose an `Action` enum and a `reduce(_ action:)` async function, with `send(_:)` calling `reduce` and then forwarding to a parent-provided `action` closure. This is the only way views mutate state.
+
+- When adding a new screen, create a `Store` in `Model/Stores/`, define its `Action`, and pair it with a SwiftUI `View` that calls `store.send(...)`.
+- All state mutation and control flow initiated by the UI must go through `Action` + `reduce(_:)`. Views call `store.send(...)` and read `@Observable` state — nothing else.
+- **Views must not contain logic.** No conditionals over multiple state fields, no derived computations beyond trivial formatting, no direct dependency calls, no `Task { ... }` blocks that reach for repositories or services. If a view feels like it wants an `if`, express that decision in the store and expose the result as state.
+
+## Cross-cutting state
+
+Global app state flows through `AppStateClient` (an `AllocatedUnfairLock<AppState>`). Async streams in `AppState` (e.g. `metrics`, `runnerBundles`, `runnerSpeeds`) are produced by services and consumed by stores via `for await` loops launched inside `reduce(.task)`.
+
+`AppDependencies.shared` is the live singleton injected through the `\.appDependencies` SwiftUI environment value; tests construct one via `AppDependencies.testDependencies(...)`, overriding only the clients they care about.
+
+## Resources
+
+- Asset Catalog and String Catalog lookups (`Image(...)`, `String(localized:)`, `Text("key", bundle: .module)`, `.module` bundle references, etc.) must **only** appear in `UserInterface`.
+- **`Model` must not reference bundle resources.** Logic that reasons about "which image / which localized string" belongs in the UI layer. In the logic layer, represent the choice as a plain-value key — an enum case, an entity ID, a semantic constant — that `UserInterface` maps to the concrete resource. This keeps `Model` testable without a resource bundle and keeps localization decisions out of business logic.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,24 +16,14 @@ CI (`.github/workflows/test.yml`) runs on tag pushes only — local test runs ar
 
 ## Architecture (LUCA)
 
-The codebase follows the [LUCA architecture](https://github.com/Kyome22/LUCA) — three SPM library targets with strict layering:
+The codebase follows the [LUCA architecture](https://github.com/Kyome22/LUCA) — three SPM library targets with strict, one-way layering: `DataSource` (leaf) ← `Model` ← `UserInterface`. Never invert.
 
-- **`DataSource`** — leaf layer. Holds `Entities` (plain values: `AppState`, `Metrics`, `Runner`, `AsyncStreamBundle`, etc.), `Dependencies` (thin `Sendable` wrappers around system APIs like `UserDefaults`, `NSWorkspace`, `FileManager`, `SMAppService`), and `Repositories` (composed of dependencies). Every dependency conforms to `DependencyClient` and exposes `liveValue` + `testValue` so tests can inject overrides via `testDependency(of:injection:)`.
-- **`Model`** — depends on `DataSource`. Holds `Services` (long-lived workers wired in `AppDelegate` — `MetricsService`, `RunnerService`, `LogService`) and `Stores` (`@MainActor @Observable` view-models conforming to `Composable`: `Dashboard`, `RunnerBar`, `MetricsBar`, settings stores). Also exposes `AppDependencies`, the bag of all dependency clients passed everywhere, plus the `AppDelegate`.
-- **`UserInterface`** — depends on `DataSource` + `Model`. Holds SwiftUI `Scenes` (`RunnerBarScene`, `MetricsBarScene`, `SettingsWindowScene`) and `Views`. Localized strings and assets live in `UserInterface/Resources`.
+- **`DataSource`** — `Entities`, `Dependencies` (conform to `DependencyClient`, expose `liveValue` + `testValue`), `Repositories`.
+- **`Model`** — `Services` (`MetricsService`, `RunnerService`, `LogService`), `Stores` (`@MainActor @Observable`, conform to `Composable`: `Dashboard`, `RunnerBar`, `MetricsBar`, settings stores), `AppDependencies`, `AppDelegate`. Application logic lives here.
+- **`UserInterface`** — SwiftUI `Scenes` (`RunnerBarScene`, `MetricsBarScene`, `SettingsWindowScene`), `Views`, and resources in `UserInterface/Resources/`.
 
-Never invert these dependencies (UI must not be imported by Model; Model must not be imported by DataSource).
-
-### Stores and the Composable pattern
-
-Stores implement `Composable`: they expose an `Action` enum and a `reduce(_ action:)` async function, with `send(_:)` calling `reduce` then forwarding to a parent-provided `action` closure. This is the only way views mutate state. When adding a new screen, create a `Store` in `Model/Stores/`, define its `Action`, and pair it with a SwiftUI `View` that calls `store.send(...)`.
-
-### Cross-cutting state
-
-Global app state flows through `AppStateClient` (an `AllocatedUnfairLock<AppState>`). Async streams in `AppState` (e.g. `metrics`, `runnerBundles`, `runnerSpeeds`) are produced by services and consumed by stores via `for await` loops launched inside `reduce(.task)`.
-
-`AppDependencies.shared` is the live singleton injected through the `\.appDependencies` SwiftUI environment value; tests construct one via `AppDependencies.testDependencies(...)`, overriding only the clients they care about.
+See [ARCHITECTURE.md](ARCHITECTURE.md) for the authoritative rules — including how `DependencyClient` couples with test design (thin, untested boundaries; logic lives in `Service`/`Store`), the Composable/Store pattern (Views mutate state only via `store.send(Action)`), cross-cutting state via `AppStateClient` and `AppDependencies`, and resource-layering constraints (`Model` must not reference Asset/String Catalog resources).
 
 ## Code Conventions
 
-`CODING_STYLE.md` defines the authoritative style rules (language, naming, comments, formatting, license headers) — read and follow it when editing code. Contribution process rules (one PR per concern, PR/issue templates, review etiquette) live in `CONTRIBUTING.md`.
+`CODING_STYLE.md` defines line-level style rules (language, naming, comments, formatting, license headers). Architecture-level rules live in `ARCHITECTURE.md`. Contribution process rules (one PR per concern, PR/issue templates, review etiquette, localization policy, feature-request cost/benefit bar) live in `CONTRIBUTING.md`.

--- a/CODING_STYLE.md
+++ b/CODING_STYLE.md
@@ -1,6 +1,6 @@
 # Coding Style Guidelines
 
-These are the authoritative style rules for all Swift code in this repository.
+These are the authoritative line-level style rules for all Swift code in this repository. For architecture-level rules (layering, `DependencyClient` boundaries, Store/View responsibilities, resource placement), see [ARCHITECTURE.md](ARCHITECTURE.md).
 
 ## Language
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,9 @@ This document describes the rules, steps, and expectations for contributing to t
   - [Bug Reports](#bug-reports)
   - [Feature Requests](#feature-requests)
   - [Other Issues](#other-issues)
+- [Localization](#localization)
+  - [Requesting a New Language](#requesting-a-new-language)
+  - [Contributing a Translation](#contributing-a-translation)
 - [Pull Requests](#pull-requests)
   - [Before Opening a Pull Request](#before-opening-a-pull-request)
   - [Cloning and Working on the Repository](#cloning-and-working-on-the-repository)
@@ -39,6 +42,11 @@ This document describes the rules, steps, and expectations for contributing to t
 ---
 
 ## Issues
+
+> [!IMPORTANT]
+> **One issue = one topic.** If your report or request is not exactly the same as an existing issue, open a **new** issue instead of piling replies onto the existing one. Cross-link related issues by writing `Related: #123` in a comment — but do not stack similar-but-distinct problems or ideas as a tree of comments under a single issue. Each issue must be triageable, discussable, and closeable on its own.
+
+---
 
 ### Bug Reports
 
@@ -60,14 +68,20 @@ To report a bug:
 > Custom runners are showcased and distributed in the [Runner Gallery](https://runcat-dev.github.io/RunnerGallery/) — please make such requests there.
 > Feature requests here should be about the app itself.
 
+> [!IMPORTANT]
+> **"Would be convenient" is not sufficient.** Every accepted feature carries an ongoing maintenance cost — code to keep alive, edge cases to test, translations to ship, regressions to answer for. A request is accepted only when its **benefit × breadth of need** clearly outweighs that cost. Requests that mainly serve a single user, replicate what the OS or an existing feature already handles, or trade a large maintenance surface for a small convenience will be declined even if the idea itself is reasonable.
+
 To suggest a new feature:
 
-1. Check if a similar feature request already exists.  
-   If so, please contribute to the existing discussion instead of opening a new one.
-2. Ensure your suggestion benefits a broad range of users and is not only a personal preference.
+1. Check if the **same** feature request already exists.  
+   If it does, add supporting information there instead of opening a duplicate. For a **similar-but-distinct** idea, open a new issue and cross-link the related one — do not stack it as a reply.
+2. Confirm that the feature benefits a broad range of users and that its benefit clearly exceeds the ongoing maintenance cost it would add.
 3. Click `New issue` and select the `Feature Request` template.
-4. Fill out the template as clearly and completely as possible.
+4. Fill out the template as clearly and completely as possible — in particular, explain **who** benefits, **how much**, and **why the benefit is worth the maintenance cost**.
 5. Submit the issue and remain available for follow-up questions.
+
+> [!NOTE]
+> Requests to add a new **UI language** are welcome as Feature Requests — see [Localization](#localization).
 
 ---
 
@@ -83,6 +97,30 @@ To suggest a new feature:
 
 ---
 
+## Localization
+
+RunCat Neo ships translations that real users read every day, so localization is treated as its own contribution track with rules that differ from ordinary code contributions.
+
+### Requesting a New Language
+
+If you want RunCat Neo to support a language it does not yet ship with, **open an issue** using the `Feature Request` template and state:
+
+- the target language, and
+- your reason for the request (e.g. size of the audience, personal need).
+
+**Do not open a translation pull request unless you can meet the standard in [Contributing a Translation](#contributing-a-translation).** Filing an issue is enough, and it is the preferred path — maintainers will decide whether and when to add the language.
+
+### Contributing a Translation
+
+Translation pull requests are held to a strict standard because the strings ship to real users:
+
+- **Only hand-crafted, human-authored translations are accepted.** Pull requests whose strings were produced by machine translators or LLMs (e.g. Google Translate, DeepL, ChatGPT, Claude) will be closed without merge. If machine-quality translation were acceptable here, maintainers would run it themselves — the value of a community translation PR is the human care put into every single string.
+- Translate **every entry** in [`Localizable.xcstrings`](LocalPackage/Sources/UserInterface/Resources/Localizable.xcstrings) and [`RunnerNames.xcstrings`](LocalPackage/Sources/UserInterface/Resources/RunnerNames.xcstrings). Verify each string fits its UI context (menu items, tooltips, settings labels) and that punctuation, spacing, and casing follow your language's conventions.
+- Declare in the pull request description that the translation is entirely human-authored, and note whether you are a native or fluent speaker of the target language.
+- If you cannot translate every string by hand, please file a [language request issue](#requesting-a-new-language) instead of opening a partial or machine-assisted PR.
+
+---
+
 ## Pull Requests
 
 ### Before Opening a Pull Request
@@ -92,6 +130,8 @@ To suggest a new feature:
 - Follow the existing formatting and conventions used in the codebase.
 - Keep each pull request focused on **a single change or context**.
   For multiple unrelated changes, create separate pull requests.
+- **Keep the diff minimal.** Small, focused pull requests get reviewed faster and more carefully. Do not fold refactors, cleanup, whitespace fixes, or drive-by improvements into a change request — file those as separate PRs. Reviewer attention is the bottleneck; every unrelated line you add costs some of it.
+- **Localization pull requests have additional rules.** See [Localization](#localization) — only hand-crafted, human-authored translations are accepted.
 - Keep code clean, readable, and easy to understand.
 - This repository is licensed under **Apache-2.0**.
 
@@ -153,8 +193,18 @@ To suggest a new feature:
 
 ## Code Style Guidelines
 
-All style rules are defined in [CODING_STYLE.md](CODING_STYLE.md).
-Follow them together with the existing conventions in the codebase.
+Two documents define the rules for code shape. Follow both, together with the existing conventions in the codebase:
+
+- **[ARCHITECTURE.md](ARCHITECTURE.md)** — the [LUCA architecture](https://github.com/Kyome22/LUCA) rules: layer responsibilities, dependency direction, `DependencyClient` boundaries, the Store/Composable pattern, and resource placement.
+- **[CODING_STYLE.md](CODING_STYLE.md)** — line-level style: naming, formatting, comments, patterns, license headers.
+
+Key architectural rules that most PRs need to check:
+
+- **`DependencyClient` is a spot-mock boundary, not a place for logic.** Clients are never covered by tests, so anything more than one direct call into the underlying system API silently degrades the test guarantees the rest of the code depends on.
+- **`UserInterface` (SwiftUI views) must not contain logic.** All state changes go through a `Composable` store's `Action`.
+- **`Model` must not reference Asset Catalog or String Catalog resources.** Resource lookup lives only in `UserInterface`.
+
+Pull requests that violate these boundaries will need to be restructured before merge.
 
 ---
 


### PR DESCRIPTION
## Context of Contribution

- [x] Others — documentation and contributor policy maintenance (no app behavior change).

## Summary of the Proposal

Contributor-facing docs and Issue/PR templates maintenance pass. In detail:

- **Split LUCA rules into a new [`ARCHITECTURE.md`](../blob/docs/refresh-contributor-policies/ARCHITECTURE.md).** It is now the single authoritative source for layer responsibilities, `DependencyClient` boundaries (thin untested spot-mocks — no logic), the Store/Composable pattern, cross-cutting state via `AppStateClient`/`AppDependencies`, and resource-layering constraints (`Model` must not touch Asset/String Catalog). `CODING_STYLE.md` now scopes to line-level style; `CLAUDE.md` is thinned to point at `ARCHITECTURE.md` and avoid duplication.
- **Localization contribution track added to `CONTRIBUTING.md`.** New-language requests are filed as Feature Requests. Translation PRs must be entirely human-authored — machine/LLM translations are rejected (if AI translation were acceptable, maintainers would run it themselves; the value of a community PR is the human care put into each string).
- **One-issue-per-topic rule** across the Issues section and both Issue templates. Similar-but-distinct reports get their own issue with `Related: #N` cross-links instead of piling replies onto an existing one.
- **Feature Request acceptance bar raised.** \"Would be convenient\" is not sufficient — requesters must justify benefit × breadth of need vs. ongoing maintenance cost. The template's \"Reason\" field is reframed to ask for that directly.
- **Minimal-diff PR rule** added to `CONTRIBUTING.md`, and a LUCA-layering checklist item added to the PR template.
- **Issue templates slimmed.** The Bug and Feature Request templates had grown to walls of text that would not get read — the intros are trimmed to 1–2 lines, redundant textarea descriptions are removed, and the checklists collapse near-duplicate items so the enforcement checkboxes actually register.

## Reason for the new feature

N/A — documentation and contributor policy only, no code or product behavior changes.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) and agree to follow it.
- [x] This PR does not contain commits of multiple contexts.
- [x] The diff is minimal — no unrelated refactors, whitespace churn, or drive-by cleanups.
- [x] Code follows proper indentation and naming conventions.
- [x] Layering follows the [LUCA architecture](../blob/main/ARCHITECTURE.md): no logic in \`DependencyClient\`, no logic in \`UserInterface\` views, no Asset/String Catalog references from \`Model\`. *(vacuous — no code changes)*
- [x] Implemented using only APIs that can be submitted to the App Store. *(vacuous — no code changes)*
- [ ] **Localization PRs only:** N/A — not a localization PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)