### PR TITLE
Support reordering custom runners and custom metrics sources

### DIFF
--- a/LocalPackage/Sources/DataSource/Entities/Events/CriticalEvent.swift
+++ b/LocalPackage/Sources/DataSource/Entities/Events/CriticalEvent.swift
@@ -24,6 +24,7 @@ public enum CriticalEvent {
     case setupFailed(any Error)
     case savingCustomRunnerFailed(any Error)
     case deletingCustomRunnerFailed(any Error)
+    case sortingCustomRunnersFailed(any Error)
     case unknown(any Error)
 
     public var message: Logger.Message {
@@ -34,6 +35,8 @@ public enum CriticalEvent {
             "Failed saving custom runner."
         case .deletingCustomRunnerFailed:
             "Failed deleting custom runner."
+        case .sortingCustomRunnersFailed:
+            "Failed sorting custom runners."
         case .unknown:
             "An unknown error has occurred."
         }
@@ -44,6 +47,7 @@ public enum CriticalEvent {
         case let .setupFailed(error),
             let .savingCustomRunnerFailed(error),
             let .deletingCustomRunnerFailed(error),
+            let .sortingCustomRunnersFailed(error),
             let .unknown(error):
             ["cause": "\(error.localizedDescription)"]
         }

--- a/LocalPackage/Sources/DataSource/Entities/Runner/RunnerBundle.swift
+++ b/LocalPackage/Sources/DataSource/Entities/Runner/RunnerBundle.swift
@@ -18,9 +18,11 @@
  limitations under the License.
  */
 
-public struct RunnerBundle: Sendable, Equatable {
+public struct RunnerBundle: Sendable, Equatable, Identifiable {
     public var runner: Runner
     public var displayFormat: DisplayFormat
+
+    public var id: Runner.ID { runner.id }
 
     public init(runner: Runner, frames: [Frame]) {
         self.runner = runner

--- a/LocalPackage/Sources/Model/Services/CustomMetricsService.swift
+++ b/LocalPackage/Sources/Model/Services/CustomMetricsService.swift
@@ -82,6 +82,12 @@ struct CustomMetricsService {
         userDefaultsRepository.metricsBarConfiguration = metricsBarConfiguration
     }
 
+    func moveSources(fromOffsets source: IndexSet, toOffset destination: Int) {
+        var configuration = userDefaultsRepository.customMetricsConfiguration
+        configuration.sources.move(fromOffsets: source, toOffset: destination)
+        userDefaultsRepository.customMetricsConfiguration = configuration
+    }
+
     func perform(action: (_ securityScopedURL: URL) -> Void, for source: CustomMetricsSource) throws {
         let (isStale, url) = try urlClient.create(source.bookmark, .withSecurityScope)
         if isStale, let refreshed = try? urlClient.bookmarkData(url, .withSecurityScope) {

--- a/LocalPackage/Sources/Model/Services/RunnerService.swift
+++ b/LocalPackage/Sources/Model/Services/RunnerService.swift
@@ -118,7 +118,7 @@ struct RunnerService {
         return Frame.custom(data)
     }
 
-    func save(customRunner runner: Runner, with frameImages: [FrameImage]) throws {
+    func add(customRunner runner: Runner, with frameImages: [FrameImage]) throws {
         let imageDataList: [Data] = try frameImages.map {
             try dataClient.convert($0.cgImage, .png)
         }
@@ -140,6 +140,13 @@ struct RunnerService {
         runners.removeAll { $0 == runner }
         try applicationSupportRepository.saveCustomRunners(runners)
         applicationSupportRepository.delete(directory: runner.id)
+        loadRunnerBundleList()
+    }
+
+    func move(fromOffsets source: IndexSet, toOffset destination: Int) throws {
+        var runners = applicationSupportRepository.loadCustomRunners()
+        runners.move(fromOffsets: source, toOffset: destination)
+        try applicationSupportRepository.saveCustomRunners(runners)
         loadRunnerBundleList()
     }
 }

--- a/LocalPackage/Sources/Model/Stores/CustomMetricsSettings.swift
+++ b/LocalPackage/Sources/Model/Stores/CustomMetricsSettings.swift
@@ -81,6 +81,25 @@ public final class CustomMetricsSettings: Composable {
             task?.cancel()
             task = nil
 
+        case let .removeCustomMetricsSourceButtonTapped(id):
+            pendingRemovalSourceID = id
+            showingConfirmationDialog = true
+
+        case let .customMetricsSourceLinkTapped(source):
+            do {
+                try customMetricsService.perform(
+                    action: { nsWorkspaceClient.activateFileViewerSelecting([$0]) },
+                    for: source
+                )
+            } catch {
+                await send(.onError(.customMetrics(.fileUnreadable)))
+            }
+
+        case let .onMoveCustomMetricsSourceRow(indexSet, offset):
+            customMetricsService.moveSources(fromOffsets: indexSet, toOffset: offset)
+            customMetricsSources = userDefaultsRepository.customMetricsConfiguration.sources
+            customMetricsService.emitConfigurationChange()
+
         case .addCustomMetricsSourceButtonTapped:
             showingFileImporter = true
 
@@ -101,10 +120,6 @@ public final class CustomMetricsSettings: Composable {
         case let .onCompletionFileImporter(.failure(error)):
             logService.error(.importingCustomMetricsSourceFailed(error))
 
-        case let .removeCustomMetricsSourceButtonTapped(id):
-            pendingRemovalSourceID = id
-            showingConfirmationDialog = true
-
         case .removingCustomMetricsSourceConfirmed:
             guard let sourceID = pendingRemovalSourceID else { return }
             customMetricsService.removeSource(of: sourceID)
@@ -114,16 +129,6 @@ public final class CustomMetricsSettings: Composable {
 
         case .removingCustomMetricsSourceCancelled:
             pendingRemovalSourceID = nil
-
-        case let .customMetricsSourceLinkTapped(source):
-            do {
-                try customMetricsService.perform(
-                    action: { nsWorkspaceClient.activateFileViewerSelecting([$0]) },
-                    for: source
-                )
-            } catch {
-                await send(.onError(.customMetrics(.fileUnreadable)))
-            }
 
         case .onError:
             return
@@ -144,13 +149,14 @@ public final class CustomMetricsSettings: Composable {
     public enum Action: Sendable {
         case task
         case onDisappear
+        case removeCustomMetricsSourceButtonTapped(UUID)
+        case customMetricsSourceLinkTapped(CustomMetricsSource)
+        case onMoveCustomMetricsSourceRow(IndexSet, Int)
         case addCustomMetricsSourceButtonTapped
         case helpButtonTapped
         case onCompletionFileImporter(Result<URL, any Error>)
-        case removeCustomMetricsSourceButtonTapped(UUID)
         case removingCustomMetricsSourceConfirmed
         case removingCustomMetricsSourceCancelled
-        case customMetricsSourceLinkTapped(CustomMetricsSource)
         case onError(RCNError)
     }
 }

--- a/LocalPackage/Sources/Model/Stores/CustomRunnerSettings.swift
+++ b/LocalPackage/Sources/Model/Stores/CustomRunnerSettings.swift
@@ -95,20 +95,6 @@ public final class CustomRunnerSettings: Composable {
         case .onDisappear:
             task?.cancel()
             task = nil
-            
-        case .addCustomRunnerButtonTapped:
-            showingCustomRunnerEditorSheet = true
-            
-        case .cancelButtonTapped:
-            showingCustomRunnerEditorSheet = false
-            
-        case .onDissmissSheet:
-            runnerName = ""
-            isTemplate = true
-            frameImages.removeAll()
-            selectingFrameImage = nil
-            previewingFrameImage = nil
-            previewSpeed = 1
 
         case let .deleteButtonTapped(runner):
             guard let currentRunner = appStateClient.withLock(\.runnerBundles.latestValue)?.runner else {
@@ -126,21 +112,43 @@ public final class CustomRunnerSettings: Composable {
                 logService.critical(.deletingCustomRunnerFailed(error))
             }
 
+        case let .onMoveCustomRunnerRow(indexSet, offset):
+            customRunnerBundleList.move(fromOffsets: indexSet, toOffset: offset)
+            do {
+                try runnerService.move(fromOffsets: indexSet, toOffset: offset)
+            } catch {
+                logService.critical(.sortingCustomRunnersFailed(error))
+            }
+
+        case .addCustomRunnerButtonTapped:
+            showingCustomRunnerEditorSheet = true
+
+        case .cancelButtonTapped:
+            showingCustomRunnerEditorSheet = false
+
+        case .onDissmissSheet:
+            runnerName = ""
+            isTemplate = true
+            frameImages.removeAll()
+            selectingFrameImage = nil
+            previewingFrameImage = nil
+            previewSpeed = 1
+
         case let .selectRenderingMode(renderingMode):
             isTemplate = renderingMode.isTemplate
-
-        case let .onDragFrameImageCell(frameImage):
-            selectingFrameImage = frameImage
             
         case let .onTapFrameImageCell(frameImage):
             selectingFrameImage = frameImage
-            
+
         case .onTapCollectionBackground:
             selectingFrameImage = nil
             
-        case let .onDropCollection(urls):
+        case let .onDropFiles(urls):
             do {
-                try urls.forEach { url in
+                let sortedURLs = urls.sorted {
+                    $0.lastPathComponent.localizedStandardCompare($1.lastPathComponent) == .orderedAscending
+                }
+                try sortedURLs.forEach { url in
                     if url.pathExtension.lowercased() == "png" {
                         try appendFrameImage(from: url)
                     }
@@ -199,7 +207,7 @@ public final class CustomRunnerSettings: Composable {
                 )
                 do {
                     let frame = try runnerService.convertToCustomFrame(from: frameImage)
-                    try runnerService.save(customRunner: runner, with: frameImages)
+                    try runnerService.add(customRunner: runner, with: frameImages)
                     customRunnerBundleList.append(.init(runner: runner, frame: frame))
                 } catch {
                     logService.critical(.savingCustomRunnerFailed(error))
@@ -243,14 +251,14 @@ public final class CustomRunnerSettings: Composable {
         case task
         case onDisappear
         case deleteButtonTapped(Runner)
+        case onMoveCustomRunnerRow(IndexSet, Int)
         case addCustomRunnerButtonTapped
         case cancelButtonTapped
         case onDissmissSheet
         case selectRenderingMode(RenderingMode)
-        case onDragFrameImageCell(FrameImage)
         case onTapFrameImageCell(FrameImage)
         case onTapCollectionBackground
-        case onDropCollection([URL])
+        case onDropFiles([URL])
         case addFrameButtonTapped
         case deleteFrameButtonTapped
         case onCompletionFileImporter(Result<[URL], any Error>)

--- a/LocalPackage/Sources/Model/Stores/Dashboard.swift
+++ b/LocalPackage/Sources/Model/Stores/Dashboard.swift
@@ -91,15 +91,15 @@ public final class Dashboard: Composable {
             guard let url = nsWorkspaceClient.urlForApplication(.activityMonitor) else { return }
             nsWorkspaceClient.openApplication(url, .init())
 
-        case let .openSourceLicenseButtonTapped(openWindow):
-            nsAppClient.activate(true)
-            openWindow(id: .openSourceLicense, value: Int.zero)
-
         case let .aboutButtonTapped(body):
             nsAppClient.activate(true)
             nsAppClient.orderFrontStandardAboutPanel([
                 NSApplication.AboutPanelOptionKey.credits: NSAttributedString(body)
             ])
+
+        case let .openSourceLicenseButtonTapped(openWindow):
+            nsAppClient.activate(true)
+            openWindow(id: .openSourceLicense, value: Int.zero)
 
         case .reportIssueButtonTapped:
             _ = nsWorkspaceClient.open(URL.githubIssues)

--- a/LocalPackage/Sources/UserInterface/Extensions/Runner+Extension.swift
+++ b/LocalPackage/Sources/UserInterface/Extensions/Runner+Extension.swift
@@ -19,15 +19,14 @@
  */
 
 import DataSource
-import SwiftUI
 
 extension Runner {
-    var displayText: Text {
+    var formatted: String {
         switch source {
         case let .builtIn(kind):
-            Text(kind.localizedName)
+            kind.localizedName
         case let .custom(name):
-            Text(name)
+            name
         }
     }
 }

--- a/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSettingsSectionView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSettingsSectionView.swift
@@ -26,17 +26,24 @@ struct CustomMetricsSettingsSectionView: View {
 
     var body: some View {
         Section {
-            ForEach(store.customMetricsSources) { source in
-                CustomMetricsSourceRowView(
-                    source: source,
-                    isErrorDetected: store.failedCustomMetricsSourceIDs.contains(source.id),
-                    removeButtonTapped: {
-                        await store.send(.removeCustomMetricsSourceButtonTapped(source.id))
-                    },
-                    sourceLinkTapped: {
-                        await store.send(.customMetricsSourceLinkTapped(source))
+            List {
+                ForEach(store.customMetricsSources) { source in
+                    CustomMetricsSourceRowView(
+                        source: source,
+                        isErrorDetected: store.failedCustomMetricsSourceIDs.contains(source.id),
+                        removeButtonTapped: {
+                            await store.send(.removeCustomMetricsSourceButtonTapped(source.id))
+                        },
+                        sourceLinkTapped: {
+                            await store.send(.customMetricsSourceLinkTapped(source))
+                        }
+                    )
+                }
+                .onMove { indexSet, offset in
+                    Task {
+                        await store.send(.onMoveCustomMetricsSourceRow(indexSet, offset))
                     }
-                )
+                }
             }
             HStack {
                 Spacer()

--- a/LocalPackage/Sources/UserInterface/Views/Settings/RunnerSettings/CustomRunnerRowView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/Settings/RunnerSettings/CustomRunnerRowView.swift
@@ -1,8 +1,8 @@
 /*
- CustomMetricsSourceRowView.swift
+ CustomRunnerRowView.swift
  UserInterface
 
- Created by Takuto Nakamura on 2026/06/06.
+ Created by Takuto Nakamura on 2026/07/28.
  Copyright 2026 Kyome22 (Takuto Nakamura)
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,17 +21,15 @@
 import DataSource
 import SwiftUI
 
-struct CustomMetricsSourceRowView: View {
-    var source: CustomMetricsSource
-    var isErrorDetected: Bool
-    var removeButtonTapped: () async -> Void
-    var sourceLinkTapped: () async -> Void
+struct CustomRunnerRowView: View {
+    var runnerBundle: RunnerBundle
+    var deleteButtonTapped: () async -> Void
 
     var body: some View {
         LabeledContent {
             Button(role: .destructive) {
                 Task {
-                    await removeButtonTapped()
+                    await deleteButtonTapped()
                 }
             } label: {
                 Image(systemName: "minus.circle")
@@ -39,20 +37,10 @@ struct CustomMetricsSourceRowView: View {
             .buttonStyle(.borderless)
             .tint(Color.red)
         } label: {
-            Text(source.displayName)
-                .truncationMode(.middle)
-            HStack(spacing: 8) {
-                Text(LocalizedStringKey(stringLiteral: "\(source.fileURL.relativePath) [→](/)"))
-                    .environment(\.openURL, OpenURLAction { _ in
-                        Task {
-                            await sourceLinkTapped()
-                        }
-                        return .handled
-                    })
-                if isErrorDetected {
-                    Text("errorDetected", bundle: .module)
-                        .foregroundStyle(Color.yellow)
-                }
+            Label {
+                Text(runnerBundle.runner.formatted)
+            } icon: {
+                runnerBundle.thumbnail
             }
         }
     }

--- a/LocalPackage/Sources/UserInterface/Views/Settings/RunnerSettings/CustomRunnerSettingsSectionView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/Settings/RunnerSettings/CustomRunnerSettingsSectionView.swift
@@ -24,24 +24,29 @@ import SwiftUI
 struct CustomRunnerSettingsSectionView: View {
     @State var store: CustomRunnerSettings
 
+    private var runnerGalleryGuidance: AttributedString {
+        var text = AttributedString(String(localized: "runnerGalleryDescription", bundle: .module))
+        if let range = text.range(of: "Runner Gallery") {
+            text[range].link = URL.runnerGallery
+            text[range].foregroundColor = NSColor.linkColor
+        }
+        return text
+    }
+
     var body: some View {
         Section {
-            ForEach(store.customRunnerBundleList, id: \.runner) { runnerBundle in
-                LabeledContent {
-                    Button(role: .destructive) {
-                        Task {
+            List {
+                ForEach(store.customRunnerBundleList) { runnerBundle in
+                    CustomRunnerRowView(
+                        runnerBundle: runnerBundle,
+                        deleteButtonTapped: {
                             await store.send(.deleteButtonTapped(runnerBundle.runner))
                         }
-                    } label: {
-                        Image(systemName: "minus.circle")
-                            .foregroundStyle(Color.red)
-                    }
-                    .buttonStyle(.borderless)
-                } label: {
-                    Label {
-                        runnerBundle.runner.displayText
-                    } icon: {
-                        runnerBundle.thumbnail
+                    )
+                }
+                .onMove { indexSet, offset in
+                    Task {
+                        await store.send(.onMoveCustomRunnerRow(indexSet, offset))
                     }
                 }
             }
@@ -83,14 +88,5 @@ struct CustomRunnerSettingsSectionView: View {
                 await store.send(.onDisappear)
             }
         }
-    }
-
-    var runnerGalleryGuidance: AttributedString {
-        var text = AttributedString(String(localized: "runnerGalleryDescription", bundle: .module))
-        if let range = text.range(of: "Runner Gallery") {
-            text[range].link = URL.runnerGallery
-            text[range].foregroundColor = NSColor.linkColor
-        }
-        return text
     }
 }

--- a/LocalPackage/Sources/UserInterface/Views/Settings/RunnerSettings/FrameImageCellView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/Settings/RunnerSettings/FrameImageCellView.swift
@@ -39,6 +39,6 @@ struct FrameImageCellView: View {
         }
         .border(isSelected ? Color.accentColor : Color.clear)
         .padding(4)
-        .contentShape(Rectangle())
+        .contentShape(.rect)
     }
 }

--- a/LocalPackage/Sources/UserInterface/Views/Settings/RunnerSettings/FrameImagesCollectionView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/Settings/RunnerSettings/FrameImagesCollectionView.swift
@@ -37,27 +37,17 @@ struct FrameImagesCollectionView: View {
                             isTemplate: store.isTemplate,
                             isSelected: store.selectingFrameImage == frameImage
                         )
-                        .onDrag {
-                            Task {
-                                await store.send(.onDragFrameImageCell(frameImage))
-                            }
-                            return NSItemProvider(object: NSString(string: frameImage.id.uuidString))
-                        } preview: {
-                            Color.clear.frame(width: 40, height: 40)
-                        }
-                        .onDrop(
-                            of: [.item],
-                            delegate: FrameImageDropDelegate(
-                                index: index,
-                                frameImages: $store.frameImages,
-                                draggingFrameImage: $store.selectingFrameImage
-                            )
-                        )
                         .onTapGesture {
                             Task {
                                 await store.send(.onTapFrameImageCell(frameImage))
                             }
                         }
+                        .sortable(
+                            index: index,
+                            item: frameImage,
+                            items: $store.frameImages,
+                            draggingItem: $store.selectingFrameImage
+                        )
                     }
                 }
             }
@@ -69,7 +59,7 @@ struct FrameImagesCollectionView: View {
             }
             .dropDestination(for: URL.self) { urls, _ in
                 Task {
-                    await store.send(.onDropCollection(urls))
+                    await store.send(.onDropFiles(urls))
                 }
                 return true
             }
@@ -107,42 +97,5 @@ struct FrameImagesCollectionView: View {
         }
         .frame(width: 256, height: 180) // 256 = 48 × 5 + 4 × 4
         .border(Color(.separatorColor))
-    }
-}
-
-private struct FrameImageDropDelegate: DropDelegate {
-    var index: Int
-    @Binding var frameImages: [FrameImage]
-    @Binding var draggingFrameImage: FrameImage?
-
-    func performDrop(info: DropInfo) -> Bool {
-        if draggingFrameImage != nil, info.hasItemsConforming(to: [.text]) {
-            true
-        } else {
-            false
-        }
-    }
-
-    func dropEntered(info: DropInfo) {
-        guard let draggingFrameImage,
-              info.hasItemsConforming(to: [.text]),
-              let fromIndex = frameImages.firstIndex(of: draggingFrameImage),
-              fromIndex != index else {
-            return
-        }
-        withAnimation(.bouncy) {
-            frameImages.move(
-                fromOffsets: IndexSet(integer: fromIndex),
-                toOffset: index > fromIndex ? index + 1 : index
-            )
-        }
-    }
-
-    func dropUpdated(info: DropInfo) -> DropProposal? {
-        if info.hasItemsConforming(to: [.text]) {
-            DropProposal(operation: .move)
-        } else {
-            DropProposal(operation: .forbidden)
-        }
     }
 }

--- a/LocalPackage/Sources/UserInterface/Views/Settings/RunnerSettings/RunnerSettingsView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/Settings/RunnerSettings/RunnerSettingsView.swift
@@ -34,7 +34,7 @@ struct RunnerSettingsView: View {
                 )) {
                     ForEach(store.runnerBundleList, id: \.runner) { runnerBundle in
                         Label {
-                            runnerBundle.runner.displayText
+                            Text(runnerBundle.runner.formatted)
                         } icon: {
                             runnerBundle.thumbnail
                         }

--- a/LocalPackage/Sources/UserInterface/Views/Settings/RunnerSettings/SegmentedButtonStyle.swift
+++ b/LocalPackage/Sources/UserInterface/Views/Settings/RunnerSettings/SegmentedButtonStyle.swift
@@ -28,7 +28,7 @@ struct SegmentedButtonStyle: PrimitiveButtonStyle {
             configuration.label
                 .font(.body)
                 .frame(width: 16, height: 16)
-                .contentShape(Rectangle())
+                .contentShape(.rect)
         }
         .buttonStyle(.plain)
         .padding(4)

--- a/LocalPackage/Sources/UserInterface/Views/Settings/SortableViewModifier.swift
+++ b/LocalPackage/Sources/UserInterface/Views/Settings/SortableViewModifier.swift
@@ -1,0 +1,81 @@
+/*
+ SortableViewModifier.swift
+ UserInterface
+
+ Created by Takuto Nakamura on 2026/07/22.
+ Copyright 2026 Kyome22 (Takuto Nakamura)
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import SwiftUI
+
+private struct SortableViewModifier<Item: Hashable & Identifiable>: ViewModifier where Item.ID: Sendable & Codable {
+    var index: Int
+    var item: Item
+    @Binding var items: [Item]
+    @Binding var draggingItem: Item?
+
+    func body(content: Content) -> some View {
+        content
+            .draggable(hook(item)) {
+                Color.clear.frame(width: 40, height: 40)
+            }
+            .dropDestination(
+                for: DraggableItem.self,
+                isEnabled: true,
+                action: { _, session in
+                    if session.phase == .ended(.move) {
+                        draggingItem = nil
+                    }
+                }
+            )
+            .dropConfiguration { session in
+                if session.phase == .entering,
+                   let draggingItem, draggingItem != item,
+                   let fromIndex = items.firstIndex(of: draggingItem) {
+                    withAnimation(.bouncy) {
+                        items.move(
+                            fromOffsets: IndexSet(integer: fromIndex),
+                            toOffset: index > fromIndex ? index + 1 : index
+                        )
+                    }
+                }
+                return DropConfiguration(operation: .move)
+            }
+    }
+
+    private func hook(_ item: Item) -> DraggableItem {
+        draggingItem = item
+        return .init(id: item.id)
+    }
+
+    private struct DraggableItem: Codable, Transferable {
+        var id: Item.ID
+
+        static var transferRepresentation: some TransferRepresentation {
+            CodableRepresentation(for: DraggableItem.self, contentType: .data)
+        }
+    }
+}
+
+extension View {
+    func sortable<Item: Hashable & Identifiable>(
+        index: Int,
+        item: Item,
+        items: Binding<[Item]>,
+        draggingItem: Binding<Item?>
+    ) -> some View where Item.ID: Sendable & Codable {
+        modifier(SortableViewModifier<Item>(index: index, item: item, items: items, draggingItem: draggingItem))
+    }
+}

--- a/LocalPackage/Tests/ModelTests/ServiceTests/CustomMetricsServiceTests.swift
+++ b/LocalPackage/Tests/ModelTests/ServiceTests/CustomMetricsServiceTests.swift
@@ -125,6 +125,16 @@ struct CustomMetricsServiceTests {
     }
 
     @Test
+    func moveSources_reorders_sources_in_configuration() {
+        let firstSource = makeSource(id: UUID(1))
+        let secondSource = makeSource(id: UUID(2))
+        let storage = UserDefaultsClient.storage(initialSources: [firstSource, secondSource])
+        let sut = CustomMetricsService(.testDependencies(userDefaultsClient: storage.client))
+        sut.moveSources(fromOffsets: IndexSet(integer: 1), toOffset: 0)
+        #expect(storage.currentConfiguration() == CustomMetricsConfiguration(sources: [secondSource, firstSource]))
+    }
+
+    @Test
     func perform_passes_resolved_security_scoped_url_to_action() throws {
         let receivedURLs = AllocatedUnfairLock<[URL]>(initialState: [])
         let sut = CustomMetricsService(.testDependencies(

--- a/LocalPackage/Tests/ModelTests/ServiceTests/RunnerServiceTests.swift
+++ b/LocalPackage/Tests/ModelTests/ServiceTests/RunnerServiceTests.swift
@@ -344,7 +344,7 @@ struct RunnerServiceTests {
     }
 
     @Test
-    func save_customRunner_writes_frame_files_and_appended_custom_runners_file() throws {
+    func add_customRunner_writes_frame_files_and_appended_custom_runners_file() throws {
         let appState = AllocatedUnfairLock<AppState>(initialState: .init())
         let written = AllocatedUnfairLock<[(data: Data, url: URL)]>(initialState: [])
         let sut = RunnerService(.testDependencies(
@@ -357,7 +357,7 @@ struct RunnerServiceTests {
             }
         ))
         let runner = Runner(id: "custom-runner", name: "Custom Runner", isTemplate: false, frameOrder: .custom([0, 1]))
-        try sut.save(customRunner: runner, with: [FrameImage.dummy(), FrameImage.dummy()])
+        try sut.add(customRunner: runner, with: [FrameImage.dummy(), FrameImage.dummy()])
         let writtenFiles = written.withLock(\.self)
         #expect(writtenFiles.map(\.url.lastPathComponent) == ["frame-0.png", "frame-1.png", "CUSTOM_RUNNERS.json"])
         #expect(writtenFiles.first?.data == Data("png".utf8))
@@ -406,5 +406,82 @@ struct RunnerServiceTests {
         let expectedJSON = #"[{"frameOrder":[0],"id":"other-runner","isTemplate":false,"name":"Other Runner"}]"#
         #expect(writtenJSON.withLock(\.self) == expectedJSON)
         #expect(removedURL.withLock(\.self)?.hasPathSuffix("RunCatNeo/custom-runner") == true)
+    }
+
+    @Test
+    func move_customRunners_persists_new_order_and_reloads_bundle_list() throws {
+        let appState = AllocatedUnfairLock<AppState>(initialState: .init())
+        let storedJSON = AllocatedUnfairLock<String>(initialState: """
+            [
+              {
+                "id": "first-runner",
+                "name": "First Runner",
+                "isTemplate": false,
+                "frameOrder": [0]
+              },
+              {
+                "id": "second-runner",
+                "name": "Second Runner",
+                "isTemplate": false,
+                "frameOrder": [0]
+              }
+            ]
+            """)
+        let sut = RunnerService(.testDependencies(
+            appStateClient: .testDependency(appState),
+            dataClient: testDependency(of: DataClient.self) {
+                $0.read = { url in
+                    url.hasPathSuffix("CUSTOM_RUNNERS.json")
+                        ? Data(storedJSON.withLock(\.self).utf8)
+                        : Data("frame".utf8)
+                }
+                $0.write = { data, url in
+                    if url.hasPathSuffix("CUSTOM_RUNNERS.json") {
+                        storedJSON.withLock { $0 = String(decoding: data, as: UTF8.self) }
+                    }
+                }
+            },
+            fileManagerClient: testDependency(of: FileManagerClient.self) {
+                $0.fileExists = { _ in true }
+            }
+        ))
+        try sut.move(fromOffsets: IndexSet(integer: 1), toOffset: 0)
+        let expectedJSON = #"[{"frameOrder":[0],"id":"second-runner","isTemplate":false,"name":"Second Runner"},"#
+            + #"{"frameOrder":[0],"id":"first-runner","isTemplate":false,"name":"First Runner"}]"#
+        #expect(storedJSON.withLock(\.self) == expectedJSON)
+        let bundleList = appState.withLock(\.runnerBundleLists.latestValue)
+        #expect(bundleList?.suffix(2).map(\.runner.id) == ["second-runner", "first-runner"])
+    }
+
+    @Test
+    func move_customRunners_throws_when_saving_fails() {
+        let json = """
+            [
+              {
+                "id": "first-runner",
+                "name": "First Runner",
+                "isTemplate": false,
+                "frameOrder": [0]
+              },
+              {
+                "id": "second-runner",
+                "name": "Second Runner",
+                "isTemplate": false,
+                "frameOrder": [0]
+              }
+            ]
+            """
+        let sut = RunnerService(.testDependencies(
+            dataClient: testDependency(of: DataClient.self) {
+                $0.read = { _ in Data(json.utf8) }
+                $0.write = { _, _ in throw URLError(.unknown) }
+            },
+            fileManagerClient: testDependency(of: FileManagerClient.self) {
+                $0.fileExists = { _ in true }
+            }
+        ))
+        #expect(throws: URLError.self) {
+            try sut.move(fromOffsets: IndexSet(integer: 1), toOffset: 0)
+        }
     }
 }

--- a/LocalPackage/Tests/ModelTests/StoreTests/CustomMetricsSettingsTests.swift
+++ b/LocalPackage/Tests/ModelTests/StoreTests/CustomMetricsSettingsTests.swift
@@ -55,100 +55,6 @@ struct CustomMetricsSettingsTests {
     }
 
     @MainActor @Test
-    func send_addCustomMetricsSourceButtonTapped_shows_file_importer() async {
-        let sut = CustomMetricsSettings(.testDependencies())
-        await sut.send(.addCustomMetricsSourceButtonTapped)
-        #expect(sut.showingFileImporter == true)
-    }
-
-    @MainActor @Test
-    func send_onCompletionFileImporter_success_appends_source_and_emits_change() async {
-        let appState = AllocatedUnfairLock<AppState>(initialState: .init())
-        let storage = UserDefaultsClient.storage()
-        let fileURL = URL(filePath: "/tmp/metrics.json")
-        let json = #"{ "title": "Imported", "metrics": [], "lastUpdatedDate": "2026-06-05T04:50:40Z" }"#
-        let dataClient = testDependency(of: DataClient.self) {
-            $0.read = { _ in Data(json.utf8) }
-        }
-        let urlClient = testDependency(of: URLClient.self) {
-            $0.startAccessingSecurityScopedResource = { _ in true }
-            $0.stopAccessingSecurityScopedResource = { _ in }
-            $0.bookmarkData = { _, _ in Data([0xAB]) }
-        }
-        let sut = CustomMetricsSettings(.testDependencies(
-            appStateClient: .testDependency(appState),
-            dataClient: dataClient,
-            urlClient: urlClient,
-            userDefaultsClient: storage.client
-        ))
-        await sut.send(.onCompletionFileImporter(.success(fileURL)))
-        #expect(sut.customMetricsSources.count == 1)
-        #expect(sut.customMetricsSources.first?.displayName == "Imported")
-        #expect(sut.customMetricsSources.first?.bookmark == Data([0xAB]))
-        #expect(appState.withLock(\.customMetricsConfigurationChanges.latestValue) != nil)
-    }
-
-    @MainActor @Test
-    func send_helpButtonTapped_shows_help_popover() async {
-        let sut = CustomMetricsSettings(.testDependencies())
-        await sut.send(.helpButtonTapped)
-        #expect(sut.showingHelpPopover == true)
-    }
-
-    @MainActor @Test
-    func send_onCompletionFileImporter_forwards_error_when_file_is_unreadable() async {
-        let storage = UserDefaultsClient.storage()
-        let recorder = errorRecorder()
-        let sut = CustomMetricsSettings(
-            .testDependencies(
-                dataClient: testDependency(of: DataClient.self) {
-                    $0.read = { _ in throw URLError(.unknown) }
-                },
-                urlClient: testDependency(of: URLClient.self) {
-                    $0.startAccessingSecurityScopedResource = { _ in true }
-                },
-                userDefaultsClient: storage.client
-            ),
-            action: recorder.action
-        )
-        await sut.send(.onCompletionFileImporter(.success(URL(filePath: "/tmp/metrics.json"))))
-        #expect(recorder.lock.withLock(\.self) == .customMetrics(.fileUnreadable))
-        #expect(sut.customMetricsSources.isEmpty)
-    }
-
-    @MainActor @Test
-    func send_onCompletionFileImporter_forwards_error_when_json_is_invalid() async {
-        let storage = UserDefaultsClient.storage()
-        let recorder = errorRecorder()
-        let sut = CustomMetricsSettings(
-            .testDependencies(
-                dataClient: testDependency(of: DataClient.self) {
-                    $0.read = { _ in Data("not json".utf8) }
-                },
-                urlClient: testDependency(of: URLClient.self) {
-                    $0.startAccessingSecurityScopedResource = { _ in true }
-                },
-                userDefaultsClient: storage.client
-            ),
-            action: recorder.action
-        )
-        await sut.send(.onCompletionFileImporter(.success(URL(filePath: "/tmp/metrics.json"))))
-        #expect(recorder.lock.withLock(\.self) == .customMetrics(.invalidFormat))
-        #expect(sut.customMetricsSources.isEmpty)
-    }
-
-    @MainActor @Test
-    func send_onCompletionFileImporter_failure_does_not_throw() async {
-        struct DummyError: Error {}
-        let storage = UserDefaultsClient.storage()
-        let sut = CustomMetricsSettings(.testDependencies(
-            userDefaultsClient: storage.client
-        ))
-        await sut.send(.onCompletionFileImporter(.failure(DummyError())))
-        #expect(sut.customMetricsSources.isEmpty)
-    }
-
-    @MainActor @Test
     func send_removeCustomMetricsSourceButtonTapped_marks_pending_and_shows_dialog() async {
         let existingID = UUID(2)
         let storage = UserDefaultsClient.storage(initialSources: [
@@ -167,70 +73,6 @@ struct CustomMetricsSettingsTests {
         await sut.send(.removeCustomMetricsSourceButtonTapped(existingID))
         #expect(sut.pendingRemovalSourceID == existingID)
         #expect(sut.showingConfirmationDialog == true)
-        #expect(sut.customMetricsSources.count == 1)
-    }
-
-    @MainActor @Test
-    func send_removingCustomMetricsSourceConfirmed_removes_pending_source() async {
-        let existingID = UUID(3)
-        let storage = UserDefaultsClient.storage(initialSources: [
-            CustomMetricsSource(
-                id: existingID,
-                displayName: "Doomed",
-                fileURL: URL(filePath: "/tmp/doomed.json"),
-                bookmark: Data(),
-                createdAt: Date(timeIntervalSince1970: 0)
-            )
-        ])
-        let sut = CustomMetricsSettings(.testDependencies(
-            userDefaultsClient: storage.client
-        ))
-        await sut.send(.task)
-        await sut.send(.removeCustomMetricsSourceButtonTapped(existingID))
-        await sut.send(.removingCustomMetricsSourceConfirmed)
-        #expect(sut.customMetricsSources.isEmpty)
-        #expect(sut.pendingRemovalSourceID == nil)
-    }
-
-    @MainActor @Test
-    func send_removingCustomMetricsSourceConfirmed_with_no_pending_is_noop() async {
-        let existingID = UUID(4)
-        let storage = UserDefaultsClient.storage(initialSources: [
-            CustomMetricsSource(
-                id: existingID,
-                displayName: "Safe",
-                fileURL: URL(filePath: "/tmp/safe.json"),
-                bookmark: Data(),
-                createdAt: Date(timeIntervalSince1970: 0)
-            )
-        ])
-        let sut = CustomMetricsSettings(.testDependencies(
-            userDefaultsClient: storage.client
-        ))
-        await sut.send(.task)
-        await sut.send(.removingCustomMetricsSourceConfirmed)
-        #expect(sut.customMetricsSources.count == 1)
-    }
-
-    @MainActor @Test
-    func send_removingCustomMetricsSourceCancelled_clears_pending_without_removing() async {
-        let existingID = UUID(5)
-        let storage = UserDefaultsClient.storage(initialSources: [
-            CustomMetricsSource(
-                id: existingID,
-                displayName: "Spared",
-                fileURL: URL(filePath: "/tmp/spared.json"),
-                bookmark: Data(),
-                createdAt: Date(timeIntervalSince1970: 0)
-            )
-        ])
-        let sut = CustomMetricsSettings(.testDependencies(
-            userDefaultsClient: storage.client
-        ))
-        await sut.send(.task)
-        await sut.send(.removeCustomMetricsSourceButtonTapped(existingID))
-        await sut.send(.removingCustomMetricsSourceCancelled)
-        #expect(sut.pendingRemovalSourceID == nil)
         #expect(sut.customMetricsSources.count == 1)
     }
 
@@ -332,5 +174,192 @@ struct CustomMetricsSettingsTests {
         await sut.send(.customMetricsSourceLinkTapped(source))
         #expect(activatedURLs.withLock(\.self).isEmpty)
         #expect(recorder.lock.withLock(\.self) == .customMetrics(.fileUnreadable))
+    }
+
+    @MainActor @Test
+    func send_onMoveCustomMetricsSourceRow_reorders_sources_and_emits_change() async {
+        let appState = AllocatedUnfairLock<AppState>(initialState: .init())
+        let storage = UserDefaultsClient.storage(initialSources: [
+            CustomMetricsSource(
+                id: UUID(9),
+                displayName: "First",
+                fileURL: URL(filePath: "/tmp/first.json"),
+                bookmark: Data(),
+                createdAt: Date(timeIntervalSince1970: 0)
+            ),
+            CustomMetricsSource(
+                id: UUID(10),
+                displayName: "Second",
+                fileURL: URL(filePath: "/tmp/second.json"),
+                bookmark: Data(),
+                createdAt: Date(timeIntervalSince1970: 0)
+            ),
+        ])
+        let sut = CustomMetricsSettings(.testDependencies(
+            appStateClient: .testDependency(appState),
+            userDefaultsClient: storage.client
+        ))
+        await sut.send(.onMoveCustomMetricsSourceRow(IndexSet(integer: 1), 0))
+        #expect(sut.customMetricsSources.map(\.id) == [UUID(10), UUID(9)])
+        #expect(storage.currentConfiguration()?.sources.map(\.id) == [UUID(10), UUID(9)])
+        #expect(appState.withLock(\.customMetricsConfigurationChanges.latestValue) != nil)
+    }
+
+    @MainActor @Test
+    func send_addCustomMetricsSourceButtonTapped_shows_file_importer() async {
+        let sut = CustomMetricsSettings(.testDependencies())
+        await sut.send(.addCustomMetricsSourceButtonTapped)
+        #expect(sut.showingFileImporter == true)
+    }
+
+    @MainActor @Test
+    func send_helpButtonTapped_shows_help_popover() async {
+        let sut = CustomMetricsSettings(.testDependencies())
+        await sut.send(.helpButtonTapped)
+        #expect(sut.showingHelpPopover == true)
+    }
+
+    @MainActor @Test
+    func send_onCompletionFileImporter_success_appends_source_and_emits_change() async {
+        let appState = AllocatedUnfairLock<AppState>(initialState: .init())
+        let storage = UserDefaultsClient.storage()
+        let fileURL = URL(filePath: "/tmp/metrics.json")
+        let json = #"{ "title": "Imported", "metrics": [], "lastUpdatedDate": "2026-06-05T04:50:40Z" }"#
+        let dataClient = testDependency(of: DataClient.self) {
+            $0.read = { _ in Data(json.utf8) }
+        }
+        let urlClient = testDependency(of: URLClient.self) {
+            $0.startAccessingSecurityScopedResource = { _ in true }
+            $0.stopAccessingSecurityScopedResource = { _ in }
+            $0.bookmarkData = { _, _ in Data([0xAB]) }
+        }
+        let sut = CustomMetricsSettings(.testDependencies(
+            appStateClient: .testDependency(appState),
+            dataClient: dataClient,
+            urlClient: urlClient,
+            userDefaultsClient: storage.client
+        ))
+        await sut.send(.onCompletionFileImporter(.success(fileURL)))
+        #expect(sut.customMetricsSources.count == 1)
+        #expect(sut.customMetricsSources.first?.displayName == "Imported")
+        #expect(sut.customMetricsSources.first?.bookmark == Data([0xAB]))
+        #expect(appState.withLock(\.customMetricsConfigurationChanges.latestValue) != nil)
+    }
+
+    @MainActor @Test
+    func send_onCompletionFileImporter_forwards_error_when_file_is_unreadable() async {
+        let storage = UserDefaultsClient.storage()
+        let recorder = errorRecorder()
+        let sut = CustomMetricsSettings(
+            .testDependencies(
+                dataClient: testDependency(of: DataClient.self) {
+                    $0.read = { _ in throw URLError(.unknown) }
+                },
+                urlClient: testDependency(of: URLClient.self) {
+                    $0.startAccessingSecurityScopedResource = { _ in true }
+                },
+                userDefaultsClient: storage.client
+            ),
+            action: recorder.action
+        )
+        await sut.send(.onCompletionFileImporter(.success(URL(filePath: "/tmp/metrics.json"))))
+        #expect(recorder.lock.withLock(\.self) == .customMetrics(.fileUnreadable))
+        #expect(sut.customMetricsSources.isEmpty)
+    }
+
+    @MainActor @Test
+    func send_onCompletionFileImporter_forwards_error_when_json_is_invalid() async {
+        let storage = UserDefaultsClient.storage()
+        let recorder = errorRecorder()
+        let sut = CustomMetricsSettings(
+            .testDependencies(
+                dataClient: testDependency(of: DataClient.self) {
+                    $0.read = { _ in Data("not json".utf8) }
+                },
+                urlClient: testDependency(of: URLClient.self) {
+                    $0.startAccessingSecurityScopedResource = { _ in true }
+                },
+                userDefaultsClient: storage.client
+            ),
+            action: recorder.action
+        )
+        await sut.send(.onCompletionFileImporter(.success(URL(filePath: "/tmp/metrics.json"))))
+        #expect(recorder.lock.withLock(\.self) == .customMetrics(.invalidFormat))
+        #expect(sut.customMetricsSources.isEmpty)
+    }
+
+    @MainActor @Test
+    func send_onCompletionFileImporter_failure_does_not_throw() async {
+        struct DummyError: Error {}
+        let storage = UserDefaultsClient.storage()
+        let sut = CustomMetricsSettings(.testDependencies(
+            userDefaultsClient: storage.client
+        ))
+        await sut.send(.onCompletionFileImporter(.failure(DummyError())))
+        #expect(sut.customMetricsSources.isEmpty)
+    }
+
+    @MainActor @Test
+    func send_removingCustomMetricsSourceConfirmed_removes_pending_source() async {
+        let existingID = UUID(3)
+        let storage = UserDefaultsClient.storage(initialSources: [
+            CustomMetricsSource(
+                id: existingID,
+                displayName: "Doomed",
+                fileURL: URL(filePath: "/tmp/doomed.json"),
+                bookmark: Data(),
+                createdAt: Date(timeIntervalSince1970: 0)
+            )
+        ])
+        let sut = CustomMetricsSettings(.testDependencies(
+            userDefaultsClient: storage.client
+        ))
+        await sut.send(.task)
+        await sut.send(.removeCustomMetricsSourceButtonTapped(existingID))
+        await sut.send(.removingCustomMetricsSourceConfirmed)
+        #expect(sut.customMetricsSources.isEmpty)
+        #expect(sut.pendingRemovalSourceID == nil)
+    }
+
+    @MainActor @Test
+    func send_removingCustomMetricsSourceConfirmed_with_no_pending_is_noop() async {
+        let existingID = UUID(4)
+        let storage = UserDefaultsClient.storage(initialSources: [
+            CustomMetricsSource(
+                id: existingID,
+                displayName: "Safe",
+                fileURL: URL(filePath: "/tmp/safe.json"),
+                bookmark: Data(),
+                createdAt: Date(timeIntervalSince1970: 0)
+            )
+        ])
+        let sut = CustomMetricsSettings(.testDependencies(
+            userDefaultsClient: storage.client
+        ))
+        await sut.send(.task)
+        await sut.send(.removingCustomMetricsSourceConfirmed)
+        #expect(sut.customMetricsSources.count == 1)
+    }
+
+    @MainActor @Test
+    func send_removingCustomMetricsSourceCancelled_clears_pending_without_removing() async {
+        let existingID = UUID(5)
+        let storage = UserDefaultsClient.storage(initialSources: [
+            CustomMetricsSource(
+                id: existingID,
+                displayName: "Spared",
+                fileURL: URL(filePath: "/tmp/spared.json"),
+                bookmark: Data(),
+                createdAt: Date(timeIntervalSince1970: 0)
+            )
+        ])
+        let sut = CustomMetricsSettings(.testDependencies(
+            userDefaultsClient: storage.client
+        ))
+        await sut.send(.task)
+        await sut.send(.removeCustomMetricsSourceButtonTapped(existingID))
+        await sut.send(.removingCustomMetricsSourceCancelled)
+        #expect(sut.pendingRemovalSourceID == nil)
+        #expect(sut.customMetricsSources.count == 1)
     }
 }

--- a/LocalPackage/Tests/ModelTests/StoreTests/CustomRunnerSettingsTests.swift
+++ b/LocalPackage/Tests/ModelTests/StoreTests/CustomRunnerSettingsTests.swift
@@ -79,6 +79,103 @@ struct CustomRunnerSettingsTests {
     }
 
     @MainActor @Test
+    func send_onMoveCustomRunnerRow_reorders_list_and_persists_new_order() async {
+        let json = """
+            [
+              {
+                "id": "first-runner",
+                "name": "First Runner",
+                "isTemplate": false,
+                "frameOrder": [0]
+              },
+              {
+                "id": "second-runner",
+                "name": "Second Runner",
+                "isTemplate": false,
+                "frameOrder": [0]
+              }
+            ]
+            """
+        let writtenJSON = AllocatedUnfairLock<String?>(initialState: nil)
+        let firstBundle = RunnerBundle(
+            runner: Runner(id: "first-runner", name: "First Runner", isTemplate: false, frameOrder: .custom([0])),
+            frame: .custom(Data())
+        )
+        let secondBundle = RunnerBundle(
+            runner: Runner(id: "second-runner", name: "Second Runner", isTemplate: false, frameOrder: .custom([0])),
+            frame: .custom(Data())
+        )
+        let sut = CustomRunnerSettings(
+            .testDependencies(
+                dataClient: testDependency(of: DataClient.self) {
+                    $0.read = { url in
+                        url.hasPathSuffix("CUSTOM_RUNNERS.json") ? Data(json.utf8) : Data("frame".utf8)
+                    }
+                    $0.write = { data, _ in
+                        writtenJSON.withLock { $0 = String(decoding: data, as: UTF8.self) }
+                    }
+                },
+                fileManagerClient: testDependency(of: FileManagerClient.self) {
+                    $0.fileExists = { _ in true }
+                }
+            ),
+            customRunnerBundleList: [firstBundle, secondBundle]
+        )
+        await sut.send(.onMoveCustomRunnerRow(IndexSet(integer: 1), 0))
+        #expect(sut.customRunnerBundleList == [secondBundle, firstBundle])
+        let expectedJSON = #"[{"frameOrder":[0],"id":"second-runner","isTemplate":false,"name":"Second Runner"},"#
+            + #"{"frameOrder":[0],"id":"first-runner","isTemplate":false,"name":"First Runner"}]"#
+        #expect(writtenJSON.withLock(\.self) == expectedJSON)
+    }
+
+    @MainActor @Test
+    func send_addCustomRunnerButtonTapped_shows_editor_sheet() async {
+        let sut = CustomRunnerSettings(.testDependencies())
+        await sut.send(.addCustomRunnerButtonTapped)
+        #expect(sut.showingCustomRunnerEditorSheet == true)
+    }
+
+    @MainActor @Test
+    func send_cancelButtonTapped_hides_editor_sheet() async {
+        let sut = CustomRunnerSettings(
+            .testDependencies(),
+            showingCustomRunnerEditorSheet: true
+        )
+        await sut.send(.cancelButtonTapped)
+        #expect(sut.showingCustomRunnerEditorSheet == false)
+    }
+
+    @MainActor @Test
+    func send_onDissmissSheet_resets_editor_inputs() async {
+        let frameImage = FrameImage.dummy()
+        let sut = CustomRunnerSettings(
+            .testDependencies(),
+            runnerName: "New Runner",
+            isTemplate: false,
+            frameImages: [frameImage],
+            selectingFrameImage: frameImage,
+            previewingFrameImage: frameImage,
+            previewSpeed: 2
+        )
+        await sut.send(.onDissmissSheet)
+        #expect(sut.runnerName.isEmpty)
+        #expect(sut.isTemplate == true)
+        #expect(sut.frameImages.isEmpty)
+        #expect(sut.selectingFrameImage == nil)
+        #expect(sut.previewingFrameImage == nil)
+        #expect(sut.previewSpeed == 1)
+    }
+
+    @MainActor @Test
+    func send_selectRenderingMode_updates_isTemplate() async {
+        let sut = CustomRunnerSettings(.testDependencies())
+        await sut.send(.selectRenderingMode(.color))
+        #expect(sut.isTemplate == false)
+        await sut.send(.selectRenderingMode(.monochrome))
+        #expect(sut.isTemplate == true)
+    }
+
+    @MainActor @Test
     func send_onTapFrameImageCell_selects_frame_and_background_clears_it() async {
         let frameImage = FrameImage.dummy()
         let sut = CustomRunnerSettings(.testDependencies())
@@ -89,10 +186,10 @@ struct CustomRunnerSettingsTests {
     }
 
     @MainActor @Test
-    func send_onDropCollection_appends_valid_png_and_ignores_other_extensions() async {
+    func send_onDropFiles_appends_valid_png_and_ignores_other_extensions() async {
         let recorder = errorRecorder()
         let sut = CustomRunnerSettings(.testDependencies(), action: recorder.action)
-        await sut.send(.onDropCollection([
+        await sut.send(.onDropFiles([
             URL.fixture(name: "solid_red_30x36"),
             URL(filePath: "/tmp/ignored.json"),
         ]))
@@ -101,10 +198,10 @@ struct CustomRunnerSettingsTests {
     }
 
     @MainActor @Test
-    func send_onDropCollection_forwards_error_when_image_size_is_invalid() async {
+    func send_onDropFiles_forwards_error_when_image_size_is_invalid() async {
         let recorder = errorRecorder()
         let sut = CustomRunnerSettings(.testDependencies(), action: recorder.action)
-        await sut.send(.onDropCollection([URL.fixture(name: "solid_red_10x18")]))
+        await sut.send(.onDropFiles([URL.fixture(name: "solid_red_10x18")]))
         #expect(recorder.lock.withLock(\.self) == .customRunner(.invalidFrameImage))
         #expect(sut.frameImages.isEmpty)
     }
@@ -128,6 +225,46 @@ struct CustomRunnerSettingsTests {
         await sut.send(.deleteFrameButtonTapped)
         #expect(sut.frameImages == [secondFrameImage])
         #expect(sut.selectingFrameImage == secondFrameImage)
+    }
+
+    @MainActor @Test
+    func send_onCompletionFileImporter_appends_accessible_frame_image() async {
+        let recorder = errorRecorder()
+        let urlClient = testDependency(of: URLClient.self) {
+            $0.startAccessingSecurityScopedResource = { _ in true }
+            $0.stopAccessingSecurityScopedResource = { _ in }
+        }
+        let sut = CustomRunnerSettings(
+            .testDependencies(urlClient: urlClient),
+            action: recorder.action
+        )
+        await sut.send(.onCompletionFileImporter(.success([URL.fixture(name: "solid_red_30x36")])))
+        #expect(sut.frameImages.count == 1)
+        #expect(recorder.lock.withLock(\.self) == nil)
+    }
+
+    @MainActor @Test
+    func send_onCompletionFileImporter_skips_inaccessible_frame_image() async {
+        let recorder = errorRecorder()
+        let urlClient = testDependency(of: URLClient.self) {
+            $0.startAccessingSecurityScopedResource = { _ in false }
+        }
+        let sut = CustomRunnerSettings(
+            .testDependencies(urlClient: urlClient),
+            action: recorder.action
+        )
+        await sut.send(.onCompletionFileImporter(.success([URL.fixture(name: "solid_red_30x36")])))
+        #expect(sut.frameImages.isEmpty)
+        #expect(recorder.lock.withLock(\.self) == nil)
+    }
+
+    @MainActor @Test
+    func send_onCompletionFileImporter_failure_is_noop() async {
+        let recorder = errorRecorder()
+        let sut = CustomRunnerSettings(.testDependencies(), action: recorder.action)
+        await sut.send(.onCompletionFileImporter(.failure(URLError(.cancelled))))
+        #expect(sut.frameImages.isEmpty)
+        #expect(recorder.lock.withLock(\.self) == nil)
     }
 
     @MainActor @Test
@@ -215,100 +352,5 @@ struct CustomRunnerSettingsTests {
         await sut.send(.addButtonTapped)
         #expect(recorder.lock.withLock(\.self) == nil)
         #expect(sut.customRunnerBundleList.isEmpty)
-    }
-
-    @MainActor @Test
-    func send_addCustomRunnerButtonTapped_shows_editor_sheet() async {
-        let sut = CustomRunnerSettings(.testDependencies())
-        await sut.send(.addCustomRunnerButtonTapped)
-        #expect(sut.showingCustomRunnerEditorSheet == true)
-    }
-
-    @MainActor @Test
-    func send_cancelButtonTapped_hides_editor_sheet() async {
-        let sut = CustomRunnerSettings(
-            .testDependencies(),
-            showingCustomRunnerEditorSheet: true
-        )
-        await sut.send(.cancelButtonTapped)
-        #expect(sut.showingCustomRunnerEditorSheet == false)
-    }
-
-    @MainActor @Test
-    func send_onDissmissSheet_resets_editor_inputs() async {
-        let frameImage = FrameImage.dummy()
-        let sut = CustomRunnerSettings(
-            .testDependencies(),
-            runnerName: "New Runner",
-            isTemplate: false,
-            frameImages: [frameImage],
-            selectingFrameImage: frameImage,
-            previewingFrameImage: frameImage,
-            previewSpeed: 2
-        )
-        await sut.send(.onDissmissSheet)
-        #expect(sut.runnerName.isEmpty)
-        #expect(sut.isTemplate == true)
-        #expect(sut.frameImages.isEmpty)
-        #expect(sut.selectingFrameImage == nil)
-        #expect(sut.previewingFrameImage == nil)
-        #expect(sut.previewSpeed == 1)
-    }
-
-    @MainActor @Test
-    func send_selectRenderingMode_updates_isTemplate() async {
-        let sut = CustomRunnerSettings(.testDependencies())
-        await sut.send(.selectRenderingMode(.color))
-        #expect(sut.isTemplate == false)
-        await sut.send(.selectRenderingMode(.monochrome))
-        #expect(sut.isTemplate == true)
-    }
-
-    @MainActor @Test
-    func send_onDragFrameImageCell_selects_frame() async {
-        let frameImage = FrameImage.dummy()
-        let sut = CustomRunnerSettings(.testDependencies())
-        await sut.send(.onDragFrameImageCell(frameImage))
-        #expect(sut.selectingFrameImage == frameImage)
-    }
-
-    @MainActor @Test
-    func send_onCompletionFileImporter_appends_accessible_frame_image() async {
-        let recorder = errorRecorder()
-        let urlClient = testDependency(of: URLClient.self) {
-            $0.startAccessingSecurityScopedResource = { _ in true }
-            $0.stopAccessingSecurityScopedResource = { _ in }
-        }
-        let sut = CustomRunnerSettings(
-            .testDependencies(urlClient: urlClient),
-            action: recorder.action
-        )
-        await sut.send(.onCompletionFileImporter(.success([URL.fixture(name: "solid_red_30x36")])))
-        #expect(sut.frameImages.count == 1)
-        #expect(recorder.lock.withLock(\.self) == nil)
-    }
-
-    @MainActor @Test
-    func send_onCompletionFileImporter_skips_inaccessible_frame_image() async {
-        let recorder = errorRecorder()
-        let urlClient = testDependency(of: URLClient.self) {
-            $0.startAccessingSecurityScopedResource = { _ in false }
-        }
-        let sut = CustomRunnerSettings(
-            .testDependencies(urlClient: urlClient),
-            action: recorder.action
-        )
-        await sut.send(.onCompletionFileImporter(.success([URL.fixture(name: "solid_red_30x36")])))
-        #expect(sut.frameImages.isEmpty)
-        #expect(recorder.lock.withLock(\.self) == nil)
-    }
-
-    @MainActor @Test
-    func send_onCompletionFileImporter_failure_is_noop() async {
-        let recorder = errorRecorder()
-        let sut = CustomRunnerSettings(.testDependencies(), action: recorder.action)
-        await sut.send(.onCompletionFileImporter(.failure(URLError(.cancelled))))
-        #expect(sut.frameImages.isEmpty)
-        #expect(recorder.lock.withLock(\.self) == nil)
     }
 }

--- a/LocalPackage/Tests/ModelTests/StoreTests/DashboardTests.swift
+++ b/LocalPackage/Tests/ModelTests/StoreTests/DashboardTests.swift
@@ -67,26 +67,6 @@ struct DashboardTests {
     }
 
     @MainActor @Test
-    func send_openSourceLicenseButtonTapped() async {
-        let callStack = AllocatedUnfairLock<[String]>(initialState: [])
-        let sut = Dashboard(.testDependencies(
-            nsAppClient: testDependency(of: NSAppClient.self) {
-                $0.activate = { value in
-                    callStack.withLock { $0.append("activate: \(value)") }
-                }
-            }
-        ))
-        let openWindow = OpenWindowActionWrapper { id, value in
-            callStack.withLock { $0.append("openWindow: \(id), \(value)") }
-        }
-        await sut.send(.openSourceLicenseButtonTapped(openWindow))
-        #expect(callStack.withLock(\.self) == [
-            "activate: true",
-            "openWindow: OPEN_SOURCE_LICENSE, 0",
-        ])
-    }
-
-    @MainActor @Test
     func send_aboutButtonTapped() async {
         let callStack = AllocatedUnfairLock<[String]>(initialState: [])
         let sut = Dashboard(.testDependencies(
@@ -103,6 +83,26 @@ struct DashboardTests {
         #expect(callStack.withLock(\.self) == [
             "activate: true",
             "orderFrontStandardAboutPanel",
+        ])
+    }
+
+    @MainActor @Test
+    func send_openSourceLicenseButtonTapped() async {
+        let callStack = AllocatedUnfairLock<[String]>(initialState: [])
+        let sut = Dashboard(.testDependencies(
+            nsAppClient: testDependency(of: NSAppClient.self) {
+                $0.activate = { value in
+                    callStack.withLock { $0.append("activate: \(value)") }
+                }
+            }
+        ))
+        let openWindow = OpenWindowActionWrapper { id, value in
+            callStack.withLock { $0.append("openWindow: \(id), \(value)") }
+        }
+        await sut.send(.openSourceLicenseButtonTapped(openWindow))
+        #expect(callStack.withLock(\.self) == [
+            "activate: true",
+            "openWindow: OPEN_SOURCE_LICENSE, 0",
         ])
     }
 

--- a/LocalPackage/Tests/ModelTests/StoreTests/MetricsBarSettingsTests.swift
+++ b/LocalPackage/Tests/ModelTests/StoreTests/MetricsBarSettingsTests.swift
@@ -33,23 +33,6 @@ struct MetricsBarSettingsTests {
     }
 
     @MainActor @Test
-    func send_showsCustomMetricsToggleSwitched_persists_visibility_and_emits_change() async {
-        let appState = AllocatedUnfairLock<AppState>(initialState: .init())
-        let storage = UserDefaultsClient.storage(initialSources: [makeSource(id: UUID(1))])
-        let sut = MetricsBarSettings(.testDependencies(
-            appStateClient: .testDependency(appState),
-            userDefaultsClient: storage.client
-        ))
-        await sut.send(.showsCustomMetricsToggleSwitched(UUID(1), true))
-        #expect(sut.metricsBarConfiguration.visibleCustomMetricsSourceIDs == [UUID(1)])
-        #expect(storage.currentMetricsBarConfiguration()?.visibleCustomMetricsSourceIDs == [UUID(1)])
-        #expect(appState.withLock(\.systemMetricsConfigurationChanges.latestValue) != nil)
-        await sut.send(.showsCustomMetricsToggleSwitched(UUID(1), false))
-        #expect(sut.metricsBarConfiguration.visibleCustomMetricsSourceIDs.isEmpty)
-        #expect(storage.currentMetricsBarConfiguration()?.visibleCustomMetricsSourceIDs.isEmpty == true)
-    }
-
-    @MainActor @Test
     func send_task_refreshes_sources_when_custom_metrics_configuration_change_is_emitted() async {
         let appState = AllocatedUnfairLock<AppState>(initialState: .init())
         let storage = UserDefaultsClient.storage()
@@ -124,5 +107,22 @@ struct MetricsBarSettingsTests {
         await sut.send(.showsSystemMetricsToggleSwitched(.cpu, true))
         #expect(sut.metricsBarConfiguration.showsCPU == true)
         #expect(activationCount.withLock(\.self) == 0)
+    }
+
+    @MainActor @Test
+    func send_showsCustomMetricsToggleSwitched_persists_visibility_and_emits_change() async {
+        let appState = AllocatedUnfairLock<AppState>(initialState: .init())
+        let storage = UserDefaultsClient.storage(initialSources: [makeSource(id: UUID(1))])
+        let sut = MetricsBarSettings(.testDependencies(
+            appStateClient: .testDependency(appState),
+            userDefaultsClient: storage.client
+        ))
+        await sut.send(.showsCustomMetricsToggleSwitched(UUID(1), true))
+        #expect(sut.metricsBarConfiguration.visibleCustomMetricsSourceIDs == [UUID(1)])
+        #expect(storage.currentMetricsBarConfiguration()?.visibleCustomMetricsSourceIDs == [UUID(1)])
+        #expect(appState.withLock(\.systemMetricsConfigurationChanges.latestValue) != nil)
+        await sut.send(.showsCustomMetricsToggleSwitched(UUID(1), false))
+        #expect(sut.metricsBarConfiguration.visibleCustomMetricsSourceIDs.isEmpty)
+        #expect(storage.currentMetricsBarConfiguration()?.visibleCustomMetricsSourceIDs.isEmpty == true)
     }
 }

--- a/LocalPackage/Tests/ModelTests/StoreTests/MetricsSettingsTests.swift
+++ b/LocalPackage/Tests/ModelTests/StoreTests/MetricsSettingsTests.swift
@@ -55,6 +55,74 @@ struct MetricsSettingsTests {
     }
 
     @MainActor @Test
+    func send_showMetricsBarToggleSwitched_on_shows_notes_sheet_without_persisting() async {
+        let setCallStack = AllocatedUnfairLock<[String]>(initialState: [])
+        let sut = MetricsSettings(.testDependencies(
+            userDefaultsClient: testDependency(of: UserDefaultsClient.self) {
+                $0.set = { value, key in
+                    let entry = "set: \(key) = \(value ?? "nil")"
+                    setCallStack.withLock { $0.append(entry) }
+                }
+            }
+        ))
+        await sut.send(.showMetricsBarToggleSwitched(true))
+        #expect(sut.showingMetricsBarNotesSheet == true)
+        #expect(sut.showsMetricsBar == false)
+        #expect(setCallStack.withLock(\.self).isEmpty)
+    }
+
+    @MainActor @Test
+    func send_showMetricsBarToggleSwitched_off_persists_flag() async {
+        let setCallStack = AllocatedUnfairLock<[String]>(initialState: [])
+        let sut = MetricsSettings(.testDependencies(
+            userDefaultsClient: testDependency(of: UserDefaultsClient.self) {
+                $0.set = { value, key in
+                    let entry = "set: \(key) = \(value ?? "nil")"
+                    setCallStack.withLock { $0.append(entry) }
+                }
+            }
+        ), showsMetricsBar: true)
+        await sut.send(.showMetricsBarToggleSwitched(false))
+        #expect(sut.showingMetricsBarNotesSheet == false)
+        #expect(sut.showsMetricsBar == false)
+        #expect(setCallStack.withLock(\.self) == ["set: SHOWS_METRICS_BAR = false"])
+    }
+
+    @MainActor @Test
+    func send_changedMyMindButtonTapped_dismisses_sheet_without_enabling() async {
+        let setCallStack = AllocatedUnfairLock<[String]>(initialState: [])
+        let sut = MetricsSettings(.testDependencies(
+            userDefaultsClient: testDependency(of: UserDefaultsClient.self) {
+                $0.set = { value, key in
+                    let entry = "set: \(key) = \(value ?? "nil")"
+                    setCallStack.withLock { $0.append(entry) }
+                }
+            }
+        ), showingMetricsBarNotesSheet: true)
+        await sut.send(.changedMyMindButtonTapped)
+        #expect(sut.showingMetricsBarNotesSheet == false)
+        #expect(sut.showsMetricsBar == false)
+        #expect(setCallStack.withLock(\.self).isEmpty)
+    }
+
+    @MainActor @Test
+    func send_showButtonTapped_enables_metrics_bar_and_persists_flag() async {
+        let setCallStack = AllocatedUnfairLock<[String]>(initialState: [])
+        let sut = MetricsSettings(.testDependencies(
+            userDefaultsClient: testDependency(of: UserDefaultsClient.self) {
+                $0.set = { value, key in
+                    let entry = "set: \(key) = \(value ?? "nil")"
+                    setCallStack.withLock { $0.append(entry) }
+                }
+            }
+        ), showingMetricsBarNotesSheet: true)
+        await sut.send(.showButtonTapped)
+        #expect(sut.showingMetricsBarNotesSheet == false)
+        #expect(sut.showsMetricsBar == true)
+        #expect(setCallStack.withLock(\.self) == ["set: SHOWS_METRICS_BAR = true"])
+    }
+
+    @MainActor @Test
     func send_monitorsSystemMetricsToggleSwitched_persists_configurations_and_notifies() async throws {
         let appState = AllocatedUnfairLock<AppState>(initialState: .init())
         let activationRequests = AllocatedUnfairLock<[SystemInfoType: Bool]?>(initialState: nil)
@@ -108,74 +176,6 @@ struct MetricsSettingsTests {
         ))
         await sut.send(.monitorsSystemMetricsToggleSwitched(.cpu, false))
         #expect(toggleActivationCount.withLock(\.self) == 0)
-    }
-
-    @MainActor @Test
-    func send_showMetricsBarToggleSwitched_on_shows_notes_sheet_without_persisting() async {
-        let setCallStack = AllocatedUnfairLock<[String]>(initialState: [])
-        let sut = MetricsSettings(.testDependencies(
-            userDefaultsClient: testDependency(of: UserDefaultsClient.self) {
-                $0.set = { value, key in
-                    let entry = "set: \(key) = \(value ?? "nil")"
-                    setCallStack.withLock { $0.append(entry) }
-                }
-            }
-        ))
-        await sut.send(.showMetricsBarToggleSwitched(true))
-        #expect(sut.showingMetricsBarNotesSheet == true)
-        #expect(sut.showsMetricsBar == false)
-        #expect(setCallStack.withLock(\.self).isEmpty)
-    }
-
-    @MainActor @Test
-    func send_showMetricsBarToggleSwitched_off_persists_flag() async {
-        let setCallStack = AllocatedUnfairLock<[String]>(initialState: [])
-        let sut = MetricsSettings(.testDependencies(
-            userDefaultsClient: testDependency(of: UserDefaultsClient.self) {
-                $0.set = { value, key in
-                    let entry = "set: \(key) = \(value ?? "nil")"
-                    setCallStack.withLock { $0.append(entry) }
-                }
-            }
-        ), showsMetricsBar: true)
-        await sut.send(.showMetricsBarToggleSwitched(false))
-        #expect(sut.showingMetricsBarNotesSheet == false)
-        #expect(sut.showsMetricsBar == false)
-        #expect(setCallStack.withLock(\.self) == ["set: SHOWS_METRICS_BAR = false"])
-    }
-
-    @MainActor @Test
-    func send_showButtonTapped_enables_metrics_bar_and_persists_flag() async {
-        let setCallStack = AllocatedUnfairLock<[String]>(initialState: [])
-        let sut = MetricsSettings(.testDependencies(
-            userDefaultsClient: testDependency(of: UserDefaultsClient.self) {
-                $0.set = { value, key in
-                    let entry = "set: \(key) = \(value ?? "nil")"
-                    setCallStack.withLock { $0.append(entry) }
-                }
-            }
-        ), showingMetricsBarNotesSheet: true)
-        await sut.send(.showButtonTapped)
-        #expect(sut.showingMetricsBarNotesSheet == false)
-        #expect(sut.showsMetricsBar == true)
-        #expect(setCallStack.withLock(\.self) == ["set: SHOWS_METRICS_BAR = true"])
-    }
-
-    @MainActor @Test
-    func send_changedMyMindButtonTapped_dismisses_sheet_without_enabling() async {
-        let setCallStack = AllocatedUnfairLock<[String]>(initialState: [])
-        let sut = MetricsSettings(.testDependencies(
-            userDefaultsClient: testDependency(of: UserDefaultsClient.self) {
-                $0.set = { value, key in
-                    let entry = "set: \(key) = \(value ?? "nil")"
-                    setCallStack.withLock { $0.append(entry) }
-                }
-            }
-        ), showingMetricsBarNotesSheet: true)
-        await sut.send(.changedMyMindButtonTapped)
-        #expect(sut.showingMetricsBarNotesSheet == false)
-        #expect(sut.showsMetricsBar == false)
-        #expect(setCallStack.withLock(\.self).isEmpty)
     }
 
     @MainActor @Test


### PR DESCRIPTION
## Context of Contribution

- [ ] Bug Fix
- [ ] Refactoring
- [x] New Feature
- [ ] Localization (new language or translation update)
- [ ] Others

## Summary of the Proposal

Custom runners and custom metrics sources can now be reordered by dragging their rows in Settings, and the new order is persisted.

- **UserInterface**: both sections are wrapped in a `List` and use `onMove`, which brings the standard drag handle and drop animation. The custom runner row is extracted into `CustomRunnerRowView`.
- **Model**: new actions `CustomRunnerSettings.onMoveCustomRunnerRow` and `CustomMetricsSettings.onMoveCustomMetricsSourceRow`, backed by `RunnerService.move(fromOffsets:toOffset:)` (rewrites `CUSTOM_RUNNERS.json` and reloads the bundle list) and `CustomMetricsService.moveSources(fromOffsets:toOffset:)` (rewrites `CustomMetricsConfiguration.sources` and emits a configuration change).

Minor changes that come with it:

- The frame image reordering in the custom runner editor now goes through a reusable `SortableViewModifier` built on `draggable` / `dropDestination`, replacing the old `DropDelegate`.
- `RunnerService.save(customRunner:with:)` is renamed to `add(customRunner:with:)` so it reads as the counterpart of `delete(customRunner:)` / `move(fromOffsets:toOffset:)`.
- `Runner.displayText: Text` becomes `Runner.formatted: String`, so the row views decide how to render it.
- New `CriticalEvent.sortingCustomRunnersFailed` for the failure path of the reordering.
- Store `Action` cases and their test cases are put back in the same order, so a case and its tests stay easy to pair up.

Tests: 169 tests pass locally (`LocalPackage-Package` scheme, macOS arm64). The new actions and the two new service methods are covered.

## Reason for the new feature

The order of custom runners and custom metrics sources is the order they appear in the runner picker and the metrics bar, but until now it was fixed to the order in which they were added. The only way to move an item was to delete it and add it back — for custom runners that means re-importing every frame image. Users who register several runners or several JSON sources hit this quickly.

`onMove` on a `List` is a stock SwiftUI API, so the maintenance cost is limited to the two service methods that rewrite the persisted order, both of which are unit tested.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) and agree to follow it.
- [x] This PR does not contain commits of multiple contexts.
- [x] The diff is minimal — no unrelated refactors, whitespace churn, or drive-by cleanups.
- [x] Code follows proper indentation and naming conventions.
- [x] Layering follows the [LUCA architecture](../blob/main/ARCHITECTURE.md): no logic in `DependencyClient`, no logic in `UserInterface` views, no Asset/String Catalog references from `Model`.
- [x] Implemented using only APIs that can be submitted to the App Store.
- [ ] **Localization PRs only:** Every translated string in this PR was hand-crafted by a human translator. No machine translation or LLM output was used. See [CONTRIBUTING.md → Localization](../blob/main/CONTRIBUTING.md#localization).

## Related Issues

close #59 
