### PR TITLE
Bump SystemInfoKit to 7.2.1

### DIFF
--- a/LocalPackage/Package.resolved
+++ b/LocalPackage/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "43fa55507e3c2490011039bf8bd5f9bbaf5e9a4c96a8bdcf1bc7bc3c5bafafc8",
+  "originHash" : "362e27afd11a196439ccf87ef2ee37f839fb152046862e4d415b5c33c625b3ca",
   "pins" : [
     {
       "identity" : "allocatedunfairlock",
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Kyome22/SystemInfoKit.git",
       "state" : {
-        "revision" : "eb916b57e6bf0aca5c3856eaddc2712b533dd331",
-        "version" : "7.2.0"
+        "revision" : "4b697f7a973878c010b318a200a2e347d7d45d38",
+        "version" : "7.2.1"
       }
     }
   ],

--- a/LocalPackage/Package.swift
+++ b/LocalPackage/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log.git", exact: "1.14.0"),
         .package(url: "https://github.com/cybozu/LicenseList.git", exact: "2.5.0"),
         .package(url: "https://github.com/Kyome22/AllocatedUnfairLock.git", exact: "1.0.0"),
-        .package(url: "https://github.com/Kyome22/SystemInfoKit.git", exact: "7.2.0"),
+        .package(url: "https://github.com/Kyome22/SystemInfoKit.git", exact: "7.2.1"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Context of Contribution

- [x] Bug Fix
- [ ] Refactoring
- [ ] New Feature
- [ ] Localization (new language or translation update)
- [ ] Others

## Summary of the Proposal

Bumps SystemInfoKit from 7.2.0 to 7.2.1 (revision `4b697f7`). No source changes are needed — everything RunCat Neo touches is public API, and the changed types are internal to the library.

7.2.1 carries three fixes:

- **Fixes #65.** `BatteryRepository` released the same IOKit Mach port twice: `IOServiceClose` already destroys the port, so the following `IOObjectRelease` deallocated an invalid name. macOS 26 returned `KERN_INVALID_NAME`, macOS 27 escalates it to a fatal `EXC_GUARD`, which crashed the app within milliseconds of launch on any Mac with a battery. Confirmed on macOS 27 hardware: the `close` + `release` sequence kills the process, `release` alone survives.
- The CPU and memory readings called `mach_host_self()` four times per sample without ever deallocating the send right, leaking one user reference per call for the lifetime of the app.
- On macOS 27 the maximum capacity was read from `BatteryData.MaxCapacity`, which is the top of the percentage scale and reads `100` on every machine, so battery health was always reported as 100%.

## Reason for the new feature

Not a new feature.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) and agree to follow it.
- [x] This PR does not contain commits of multiple contexts.
- [x] The diff is minimal — no unrelated refactors, whitespace churn, or drive-by cleanups.
- [x] Code follows proper indentation and naming conventions.
- [x] Layering follows the [LUCA architecture](../blob/main/ARCHITECTURE.md): no logic in `DependencyClient`, no logic in `UserInterface` views, no Asset/String Catalog references from `Model`.
- [x] Implemented using only APIs that can be submitted to the App Store.
- [ ] **Localization PRs only:** Every translated string in this PR was hand-crafted by a human translator. No machine translation or LLM output was used. See [CONTRIBUTING.md → Localization](../blob/main/CONTRIBUTING.md#localization).

---

Build succeeded and the full suite passes locally: 169 tests, 0 failures (`DataSourceTests` 29, `ModelTests` 140) on `LocalPackage-Package` / `platform=macOS,arch=arm64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)