### PR TITLE
Fix the horizontal flip setting not reaching the status item icon

### DIFF
--- a/LocalPackage/Sources/Model/Extensions/NSImage+Extension.swift
+++ b/LocalPackage/Sources/Model/Extensions/NSImage+Extension.swift
@@ -40,7 +40,8 @@ extension NSImage {
         size = CGSize(width: size.width / scale, height: size.height / scale)
     }
 
-    func flip() {
+    func flip(enabled: Bool) {
+        guard enabled else { return }
         let filter = CIFilter.perspectiveRotate()
         filter.inputImage = ciImage
         filter.pitch = .pi

--- a/LocalPackage/Sources/Model/Stores/RunnerBar.swift
+++ b/LocalPackage/Sources/Model/Stores/RunnerBar.swift
@@ -112,17 +112,16 @@ public final class RunnerBar: Composable {
                 nil
             }
         }
+        let isFlippedHorizontally = userDefaultsRepository.isFlippedHorizontally
         icon = images.first?.plane
+        icon?.flip(enabled: isFlippedHorizontally)
         icon?.normalize()
         size = icon?.size ?? .zero
         eventBridge?.setSize(size)
-        let isFlippedHorizontally = userDefaultsRepository.isFlippedHorizontally
         isTemplate = runnerBundle.runner.isTemplate
         eventBridge?.setColor(tintColor, isTemplate)
         let imageFrames = images.map { image in
-            if isFlippedHorizontally {
-                image.flip()
-            }
+            image.flip(enabled: isFlippedHorizontally)
             image.normalize()
             image.isTemplate = isTemplate
             return image

--- a/LocalPackage/Sources/UserInterface/Views/RunnerBar/RunnerBarView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/RunnerBar/RunnerBarView.swift
@@ -21,13 +21,25 @@
 import Model
 import SwiftUI
 
+// The runner is animated by a CAKeyframeAnimation on `runnerLayer` instead of swapping the
+// MenuBarExtra icon frame by frame. Every icon swap makes the menu bar snapshot the status item in
+// both light and dark appearance for the other monitors, which measured 7-8% CPU constantly when
+// this was last profiled, against about 0.1% for the layer-based animation.
+//
+// The trade-off is that the animation renders only on the active monitor, leaving an empty gap on
+// the others, so `iconImage` is drawn as a static fallback. On the active monitor `backgroundLayer`
+// erases it again via sourceOutCompositing, so the two never overlap. That filter does not work on
+// Intel Macs, where `backgroundLayer` is therefore not installed and the gap stays empty.
 struct RunnerBarView: View {
     @StateObject var store: RunnerBar
 
     private var iconImage: NSImage {
+#if arch(arm64)
+        let icon = store.icon
+#endif
         let nsImage = NSImage(size: store.size, flipped: true) { rect in
 #if arch(arm64)
-            store.icon?.draw(in: rect)
+            icon?.draw(in: rect)
 #endif
             return true
         }


### PR DESCRIPTION
## Context of Contribution

- [x] Bug Fix
- [ ] Refactoring
- [ ] New Feature
- [ ] Localization (new language or translation update)
- [ ] Others

## Summary of the Proposal

Fixes #31.

The runner is drawn twice. `RunnerLayer` animates the flipped frames, and `RunnerBar.icon` is painted into the status item as the static fallback shown on monitors where the layer animation does not render. Two separate defects kept the horizontal flip setting out of that fallback.

**The fallback icon was never flipped.** Only the animation frames went through `flip()`, so on a monitor without focus the runner always faced the original direction — the behaviour reported in the issue.

**Changes to the icon did not invalidate the view.** `RunnerBarView` read `store.icon` from inside the `NSImage` drawing handler. That closure runs when the image is drawn, long after body evaluation, so the read never registered an Observation dependency. The body only tracked `size`, `isTemplate` and `isReady`, and toggling the flip changes none of them, so the previous image stayed in place. Switching runners appeared to work only because a different runner usually changes `size`.

Changes:

- Flip `RunnerBar.icon` with the same setting as the animation frames
- Read `store.icon` during body evaluation so an icon change invalidates the view
- Replace `flip()` with `flip(enabled:)` so both call sites stay unconditional
- Document above `RunnerBarView` why the runner is animated by a `CAKeyframeAnimation` and backed by a static fallback icon, since neither the layer trick nor the Intel compromise is discoverable from the code

The `#if arch(arm64)` guards are unchanged. On Intel the fallback icon is still not drawn, because `backgroundLayer` cannot erase it there, so the existing compromise stands.

## Reason for the new feature

N/A — bug fix.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) and agree to follow it.
- [x] This PR does not contain commits of multiple contexts.
- [x] The diff is minimal — no unrelated refactors, whitespace churn, or drive-by cleanups.
- [x] Code follows proper indentation and naming conventions.
- [x] Layering follows the [LUCA architecture](../blob/main/ARCHITECTURE.md): no logic in `DependencyClient`, no logic in `UserInterface` views, no Asset/String Catalog references from `Model`.
- [x] Implemented using only APIs that can be submitted to the App Store.
- [ ] **Localization PRs only:** Every translated string in this PR was hand-crafted by a human translator. No machine translation or LLM output was used. See [CONTRIBUTING.md → Localization](../blob/main/CONTRIBUTING.md#localization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)