### PR TITLE
Document what the Claude Code sample card shows

### DIFF
--- a/docs/samples/claude-code/README.md
+++ b/docs/samples/claude-code/README.md
@@ -23,6 +23,15 @@ A minimal Python script that lets RunCat Neo's Custom Metrics card show your Cla
 4. Run Claude Code. The card updates each turn.
 5. Optional: click the Metrics Bar and flip the source's toggle to show the context usage (`metricsBarValue`) directly in the menu bar.
 
+## What it displays
+
+- **Model** — the model name Claude Code reports for the session.
+- **Context** — how much of the context window the latest API response used. This is also what `metricsBarValue` carries into the Metrics Bar.
+- **5h**, **7d** — how much of each rate-limit window is consumed, followed by when it resets: `3% (~14:30)` when the reset falls on the same day, `3% (~7/22 03:00)` when it crosses into another day.
+
+Claude Code reports rate limits only for Claude.ai subscriptions (Pro/Max), and only after the session's first API response, so the 5h and 7d rows are absent until then.
+Each window is reported independently, and one whose reset time is missing falls back to a plain percentage.
+
 ## Already have a statusLine?
 
 `~/.claude/settings.json` only allows a single `statusLine.command`, so combine yours and this one yourself. Asking Claude works well: "Here's my existing statusline script and the RunCat sample — write me one that does both" usually produces a clean merge in one shot.


### PR DESCRIPTION
## Context of Contribution

- [ ] Bug Fix
- [ ] Refactoring
- [ ] New Feature
- [ ] Localization (new language or translation update)
- [x] Others

## Summary of the Proposal

Documentation follow-up to #58.

The Claude Code sample's README explains how to install the script but never says what ends up on the card. That was fine while every row was a plain percentage; #58 introduced a display rule you can only learn by reading the source — same-day resets render as `~HH:MM`, cross-day ones as `~M/D HH:MM`.

Two more things are worth stating, because both look like the sample is broken when they aren't:

- The 5h and 7d rows are missing until Claude Code reports rate limits, which it does only for Claude.ai subscriptions (Pro/Max) and only after the session's first API response.
- A window that arrives without a reset time falls back to a plain percentage rather than dropping the row.

Adds a **What it displays** section covering the three rows, placed after Setup — the same position and shape as the section [`docs/samples/codex/README.md`](../blob/main/docs/samples/codex/README.md) already has, so the two samples read alike.

Docs only; the script is untouched.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) and agree to follow it.
- [x] This PR does not contain commits of multiple contexts.
- [x] The diff is minimal — no unrelated refactors, whitespace churn, or drive-by cleanups.
- [x] Code follows proper indentation and naming conventions.
- [x] Layering follows the [LUCA architecture](../blob/main/ARCHITECTURE.md): no logic in `DependencyClient`, no logic in `UserInterface` views, no Asset/String Catalog references from `Model`.
- [x] Implemented using only APIs that can be submitted to the App Store.
