### PR TITLE
Recalculate the Custom Metrics relative time on every open

### DIFF
--- a/LocalPackage/Sources/Model/Stores/Dashboard.swift
+++ b/LocalPackage/Sources/Model/Stores/Dashboard.swift
@@ -26,6 +26,7 @@ import SystemInfoKit
 @MainActor @Observable
 public final class Dashboard: Composable {
     private let appStateClient: AppStateClient
+    private let dateClient: DateClient
     private let nsAppClient: NSAppClient
     private let nsWorkspaceClient: NSWorkspaceClient
     private let userDefaultsRepository: UserDefaultsRepository
@@ -38,6 +39,7 @@ public final class Dashboard: Composable {
     public var cpuRingBuffer: RingBuffer
     public var memoryRingBuffer: RingBuffer
     public var customMetricsBundles: [CustomMetricsBundle]
+    public var displayedDate: Date
     public let isPreview: Bool
     public let action: (Action) async -> Void
 
@@ -48,10 +50,12 @@ public final class Dashboard: Composable {
         cpuRingBuffer: RingBuffer = .init(),
         memoryRingBuffer: RingBuffer = .init(),
         customMetricsBundles: [CustomMetricsBundle] = [],
+        displayedDate: Date? = nil,
         isPreview: Bool? = nil,
         action: @escaping (Action) async -> Void =  { _ in }
     ) {
         self.appStateClient = appDependencies.appStateClient
+        self.dateClient = appDependencies.dateClient
         self.nsAppClient = appDependencies.nsAppClient
         self.nsWorkspaceClient = appDependencies.nsWorkspaceClient
         self.userDefaultsRepository = .init(appDependencies.userDefaultsClient)
@@ -61,6 +65,7 @@ public final class Dashboard: Composable {
         self.cpuRingBuffer = cpuRingBuffer
         self.memoryRingBuffer = memoryRingBuffer
         self.customMetricsBundles = customMetricsBundles
+        self.displayedDate = displayedDate ?? dateClient.now()
         self.isPreview = isPreview ?? ProcessInfo.isPreview
         self.action = action
     }
@@ -69,6 +74,7 @@ public final class Dashboard: Composable {
         switch action {
         case let .task(screenName):
             logService.notice(.screenView(name: screenName))
+            displayedDate = dateClient.now()
             if let metrics = appStateClient.withLock(\.metrics.latestValue) {
                 updateMetrics(metrics)
             }

--- a/LocalPackage/Sources/UserInterface/Views/RunnerBar/Dashboard/CustomMetricsCardView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/RunnerBar/Dashboard/CustomMetricsCardView.swift
@@ -24,17 +24,20 @@ import SwiftUI
 struct CustomMetricsCardView: View {
     var snapshot: CustomMetricsSnapshot
     var isFailed: Bool
+    var displayedDate: Date
 
-    init(customMetricsBundle: CustomMetricsBundle) {
+    init(customMetricsBundle: CustomMetricsBundle, displayedDate: Date) {
         self.snapshot = customMetricsBundle.snapshot
         self.isFailed = customMetricsBundle.isFailed
+        self.displayedDate = displayedDate
     }
 
     private var lastUpdatedDetail: String {
         if isFailed {
             String(localized: "failed", bundle: .module)
         } else {
-            snapshot.lastUpdatedDate.formatted(.relative(presentation: .named))
+            Date.AnchoredRelativeFormatStyle(anchor: snapshot.lastUpdatedDate, presentation: .named)
+                .format(displayedDate)
         }
     }
 

--- a/LocalPackage/Sources/UserInterface/Views/RunnerBar/Dashboard/DashboardView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/RunnerBar/Dashboard/DashboardView.swift
@@ -47,7 +47,10 @@ struct DashboardView: View {
                 isPreview: store.isPreview
             )
             ForEach(store.customMetricsBundles) { customMetricsBundle in
-                CustomMetricsCardView(customMetricsBundle: customMetricsBundle)
+                CustomMetricsCardView(
+                    customMetricsBundle: customMetricsBundle,
+                    displayedDate: store.displayedDate
+                )
             }
         }
         .fixedSize()

--- a/LocalPackage/Tests/ModelTests/StoreTests/DashboardTests.swift
+++ b/LocalPackage/Tests/ModelTests/StoreTests/DashboardTests.swift
@@ -23,6 +23,29 @@ struct DashboardTests {
     }
 
     @MainActor @Test
+    func send_task_refreshes_displayedDate_every_time_it_is_sent() async {
+        let dates = AllocatedUnfairLock<[Date]>(initialState: [
+            Date(timeIntervalSince1970: 1_000),
+            Date(timeIntervalSince1970: 2_000),
+        ])
+        let sut = Dashboard(
+            .testDependencies(
+                dateClient: testDependency(of: DateClient.self) {
+                    $0.now = { dates.withLock { $0.removeFirst() } }
+                }
+            ),
+            displayedDate: .distantPast
+        )
+        #expect(sut.displayedDate == .distantPast)
+        await sut.send(.task("DashboardTests"))
+        #expect(sut.displayedDate == Date(timeIntervalSince1970: 1_000))
+        await sut.send(.onDisappear)
+        await sut.send(.task("DashboardTests"))
+        #expect(sut.displayedDate == Date(timeIntervalSince1970: 2_000))
+        await sut.send(.onDisappear)
+    }
+
+    @MainActor @Test
     func send_onDisappear_stops_observing_metrics() async {
         let appState = AllocatedUnfairLock<AppState>(initialState: .init())
         let sut = Dashboard(.testDependencies(appStateClient: .testDependency(appState)))


### PR DESCRIPTION
## Context of Contribution

- [x] Bug Fix
- [ ] Refactoring
- [ ] New Feature
- [ ] Localization (new language or translation update)
- [ ] Others

## Summary of the Proposal

Fixes #67: the `Last updated:` line on a Custom Metrics card kept whatever relative time it showed when the card first rendered, and only caught up once the source file changed.

The line was built as a `String` at body-evaluation time, so it needed a body evaluation to move. The card's only inputs were `snapshot` and `isFailed` — both unchanged while the file sits still — so SwiftUI had an equal view value and skipped the body. The dashboard around it does re-render on every metrics tick, which is why the CPU rows stay live while this one row does not. Reopening the dashboard did not help either: the inputs were still equal. That last part is confirmed by running the app, not inferred.

The fix gives the card the moment it is being displayed as an explicit input. `Dashboard` stamps `displayedDate` from the existing `DateClient` on every `.task`, so each time the dashboard appears the input differs and the label is rebuilt. No timer and no new dependency.

`Date.AnchoredRelativeFormatStyle` accepts that reference date. Its output is identical to the previous `.relative(presentation: .named)` call — verified across 0s / 45s / 90s / 1837s / 1h / 2h / yesterday / 2 days / last week / last month / last year, with zero mismatches — so the wording, the rounding, and every localized string stay as they are.

`RelativeDateTimeFormatter.localizedString(for:relativeTo:)` also takes a reference date but truncates instead of rounding (1837s renders as `30 minutes ago` rather than `31 minutes ago`), so it was rejected.

The label still freezes if the dashboard is left open for minutes at a time, since it is now pinned to the moment the dashboard was shown. A `TimelineView` would cover that too, but a menu-bar window is rarely held open, and this keeps the card free of a repeating timer.

Covered by a new `DashboardTests` case asserting that every `.task` restamps `displayedDate`. Verified by hand: open the card, close it, wait, reopen — the label is now current.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) and agree to follow it.
- [x] This PR does not contain commits of multiple contexts.
- [x] The diff is minimal — no unrelated refactors, whitespace churn, or drive-by cleanups.
- [x] Code follows proper indentation and naming conventions.
- [x] Layering follows the [LUCA architecture](../blob/main/ARCHITECTURE.md): no logic in `DependencyClient`, no logic in `UserInterface` views, no Asset/String Catalog references from `Model`.
- [x] Implemented using only APIs that can be submitted to the App Store.
