### PR TITLE
Name Actions after the event, not the SwiftUI modifier

### DIFF
--- a/CODING_STYLE.md
+++ b/CODING_STYLE.md
@@ -64,7 +64,7 @@ These are the authoritative line-level style rules for all Swift code in this re
 
 ## Tests
 
-- Name test functions in snake_case as `subject_condition_expectation` (e.g. `decode_throws_when_title_missing`, `send_task_reloads_customMetricsSources_from_user_defaults`).
+- Name test functions in snake_case as `subject_condition_expectation` (e.g. `decode_throws_when_title_missing`, `send_viewAppeared_reloads_customMetricsSources_from_user_defaults`).
 - Compare whole `Equatable` values with a single `#expect` instead of asserting properties one by one; add `Equatable` conformance to entities when tests need it.
 - Pass the expression under test directly to `#expect` instead of binding it to a temporary constant like `actual`; bind a constant (with a meaningful name) only when multiple assertions need the same value.
 - Use `AllocatedUnfairLock` for mutable state captured by mock dependency closures.

--- a/LocalPackage/Sources/Model/Stores/CustomMetricsSettings.swift
+++ b/LocalPackage/Sources/Model/Stores/CustomMetricsSettings.swift
@@ -66,7 +66,7 @@ public final class CustomMetricsSettings: Composable {
 
     public func reduce(_ action: Action) async {
         switch action {
-        case .task:
+        case .viewAppeared:
             customMetricsSources = userDefaultsRepository.customMetricsConfiguration.sources
             refreshFailedCustomMetricsSourceIDs()
             task?.cancel()
@@ -77,7 +77,7 @@ public final class CustomMetricsSettings: Composable {
                 }
             }
 
-        case .onDisappear:
+        case .viewDisappeared:
             task?.cancel()
             task = nil
 
@@ -92,10 +92,10 @@ public final class CustomMetricsSettings: Composable {
                     for: source
                 )
             } catch {
-                await send(.onError(.customMetrics(.fileUnreadable)))
+                await send(.errorOccurred(.customMetrics(.fileUnreadable)))
             }
 
-        case let .onMoveCustomMetricsSourceRow(indexSet, offset):
+        case let .customMetricsSourceRowMoved(indexSet, offset):
             customMetricsService.moveSources(fromOffsets: indexSet, toOffset: offset)
             customMetricsSources = userDefaultsRepository.customMetricsConfiguration.sources
             customMetricsService.emitConfigurationChange()
@@ -106,19 +106,19 @@ public final class CustomMetricsSettings: Composable {
         case .helpButtonTapped:
             showingHelpPopover = true
 
-        case let .onCompletionFileImporter(.success(urls)):
+        case let .fileImporterResponse(.success(urls)):
             guard let url = urls.first else { return }
             do {
                 try customMetricsService.addSource(of: url)
                 customMetricsSources = userDefaultsRepository.customMetricsConfiguration.sources
                 customMetricsService.emitConfigurationChange()
             } catch let error as RCNError {
-                await send(.onError(error))
+                await send(.errorOccurred(error))
             } catch {
                 logService.critical(.unknown(error))
             }
 
-        case let .onCompletionFileImporter(.failure(error)):
+        case let .fileImporterResponse(.failure(error)):
             logService.error(.importingCustomMetricsSourceFailed(error))
 
         case .removingCustomMetricsSourceConfirmed:
@@ -131,7 +131,7 @@ public final class CustomMetricsSettings: Composable {
         case .removingCustomMetricsSourceCancelled:
             pendingRemovalSourceID = nil
 
-        case .onError:
+        case .errorOccurred:
             return
         }
     }
@@ -148,16 +148,16 @@ public final class CustomMetricsSettings: Composable {
     }
 
     public enum Action: Sendable {
-        case task
-        case onDisappear
+        case viewAppeared
+        case viewDisappeared
         case removeCustomMetricsSourceButtonTapped(UUID)
         case customMetricsSourceLinkTapped(CustomMetricsSource)
-        case onMoveCustomMetricsSourceRow(IndexSet, Int)
+        case customMetricsSourceRowMoved(IndexSet, Int)
         case addCustomMetricsSourceButtonTapped
         case helpButtonTapped
-        case onCompletionFileImporter(Result<[URL], any Error>)
+        case fileImporterResponse(Result<[URL], any Error>)
         case removingCustomMetricsSourceConfirmed
         case removingCustomMetricsSourceCancelled
-        case onError(RCNError)
+        case errorOccurred(RCNError)
     }
 }

--- a/LocalPackage/Sources/Model/Stores/CustomRunnerSettings.swift
+++ b/LocalPackage/Sources/Model/Stores/CustomRunnerSettings.swift
@@ -80,7 +80,7 @@ public final class CustomRunnerSettings: Composable {
 
     public func reduce(_ action: Action) async {
         switch action {
-        case .task:
+        case .viewAppeared:
             customRunnerBundleList = appStateClient.withLock(\.runnerBundleLists.latestValue)?
                 .filter(\.runner.isCustom) ?? []
             task?.cancel()
@@ -92,7 +92,7 @@ public final class CustomRunnerSettings: Composable {
                 }
             }
             
-        case .onDisappear:
+        case .viewDisappeared:
             task?.cancel()
             task = nil
 
@@ -107,12 +107,12 @@ public final class CustomRunnerSettings: Composable {
                 customRunnerBundleList.removeAll { $0.runner == runner }
                 try runnerService.delete(customRunner: runner)
             } catch let error as RCNError {
-                await send(.onError(error))
+                await send(.errorOccurred(error))
             } catch {
                 logService.critical(.deletingCustomRunnerFailed(error))
             }
 
-        case let .onMoveCustomRunnerRow(indexSet, offset):
+        case let .customRunnerRowMoved(indexSet, offset):
             customRunnerBundleList.move(fromOffsets: indexSet, toOffset: offset)
             do {
                 try runnerService.move(fromOffsets: indexSet, toOffset: offset)
@@ -126,7 +126,7 @@ public final class CustomRunnerSettings: Composable {
         case .cancelButtonTapped:
             showingCustomRunnerEditorSheet = false
 
-        case .onDissmissSheet:
+        case .sheetDismissed:
             runnerName = ""
             isTemplate = true
             frameImages.removeAll()
@@ -134,16 +134,16 @@ public final class CustomRunnerSettings: Composable {
             previewingFrameImage = nil
             previewSpeed = 1
 
-        case let .selectRenderingMode(renderingMode):
+        case let .renderingModePickerSelected(renderingMode):
             isTemplate = renderingMode.isTemplate
             
-        case let .onTapFrameImageCell(frameImage):
+        case let .frameImageCellTapped(frameImage):
             selectingFrameImage = frameImage
 
-        case .onTapCollectionBackground:
+        case .collectionBackgroundTapped:
             selectingFrameImage = nil
             
-        case let .onDropFiles(urls):
+        case let .filesDropped(urls):
             do {
                 let sortedURLs = urls.sorted {
                     $0.lastPathComponent.localizedStandardCompare($1.lastPathComponent) == .orderedAscending
@@ -154,7 +154,7 @@ public final class CustomRunnerSettings: Composable {
                     }
                 }
             } catch let error as RCNError {
-                await send(.onError(error))
+                await send(.errorOccurred(error))
             } catch {
                 logService.error(.importingFrameImagesFailed(error))
             }
@@ -175,7 +175,7 @@ public final class CustomRunnerSettings: Composable {
             }
             advanceFrameImage()
             
-        case let .onCompletionFileImporter(.success(urls)):
+        case let .fileImporterResponse(.success(urls)):
             do {
                 for url in urls {
                     guard urlClient.startAccessingSecurityScopedResource(url) else { return }
@@ -185,12 +185,12 @@ public final class CustomRunnerSettings: Composable {
                     try appendFrameImage(from: url)
                 }
             } catch let error as RCNError {
-                await send(.onError(error))
+                await send(.errorOccurred(error))
             } catch {
                 logService.error(.importingFrameImagesFailed(error))
             }
             
-        case let .onCompletionFileImporter(.failure(error)):
+        case let .fileImporterResponse(.failure(error)):
             logService.error(.importingFrameImagesFailed(error))
             
         case .addButtonTapped:
@@ -215,12 +215,12 @@ public final class CustomRunnerSettings: Composable {
                 }
                 showingCustomRunnerEditorSheet = false
             } catch let error as RCNError {
-                await send(.onError(error))
+                await send(.errorOccurred(error))
             } catch {
                 logService.critical(.unknown(error))
             }
             
-        case .onError:
+        case .errorOccurred:
             return
         }
     }
@@ -248,21 +248,21 @@ public final class CustomRunnerSettings: Composable {
     }
 
     public enum Action: Sendable {
-        case task
-        case onDisappear
+        case viewAppeared
+        case viewDisappeared
         case deleteButtonTapped(Runner)
-        case onMoveCustomRunnerRow(IndexSet, Int)
+        case customRunnerRowMoved(IndexSet, Int)
         case addCustomRunnerButtonTapped
         case cancelButtonTapped
-        case onDissmissSheet
-        case selectRenderingMode(RenderingMode)
-        case onTapFrameImageCell(FrameImage)
-        case onTapCollectionBackground
-        case onDropFiles([URL])
+        case sheetDismissed
+        case renderingModePickerSelected(RenderingMode)
+        case frameImageCellTapped(FrameImage)
+        case collectionBackgroundTapped
+        case filesDropped([URL])
         case addFrameButtonTapped
         case deleteFrameButtonTapped
-        case onCompletionFileImporter(Result<[URL], any Error>)
+        case fileImporterResponse(Result<[URL], any Error>)
         case addButtonTapped
-        case onError(RCNError)
+        case errorOccurred(RCNError)
     }
 }

--- a/LocalPackage/Sources/Model/Stores/Dashboard.swift
+++ b/LocalPackage/Sources/Model/Stores/Dashboard.swift
@@ -80,7 +80,7 @@ public final class Dashboard: Composable {
 
     public func reduce(_ action: Action) async {
         switch action {
-        case let .task(screenName):
+        case let .viewAppeared(screenName):
             logService.notice(.screenView(name: screenName))
             displayedDate = dateClient.now()
             if let metrics = appStateClient.withLock(\.metrics.latestValue) {
@@ -114,7 +114,7 @@ public final class Dashboard: Composable {
                 }
             }
 
-        case .onDisappear:
+        case .viewDisappeared:
             task?.cancel()
             task = nil
 
@@ -174,8 +174,8 @@ public final class Dashboard: Composable {
     }
 
     public enum Action: Sendable {
-        case task(String)
-        case onDisappear
+        case viewAppeared(String)
+        case viewDisappeared
         case runnerKindPickerSelected(Runner?)
         case settingsButtonTapped
         case activityMonitorButtonTapped

--- a/LocalPackage/Sources/Model/Stores/DonationSettings.swift
+++ b/LocalPackage/Sources/Model/Stores/DonationSettings.swift
@@ -54,7 +54,7 @@ public final class DonationSettings: Composable {
 
     public func reduce(_ action: Action) async {
         switch action {
-        case let .task(screenName):
+        case let .viewAppeared(screenName):
             logService.notice(.screenView(name: screenName))
 
         case .restoreSubscriptionButtonTapped:
@@ -64,12 +64,12 @@ public final class DonationSettings: Composable {
                 handle(error)
             }
 
-        case let .onReceiveProductTaskState(taskState):
+        case let .productTaskStateChanged(taskState):
             if case let .failure(error) = taskState {
                 handle(error)
             }
 
-        case let .onPurchaseCompleted(product, result):
+        case let .purchaseResponse(product, result):
             switch result {
             case let .success(.success(verificationResult)):
                 do {
@@ -87,7 +87,7 @@ public final class DonationSettings: Composable {
                 handle(error)
             }
 
-        case let .onReceiveSubscriptionTaskState(taskState):
+        case let .subscriptionTaskStateChanged(taskState):
             isSubscribed = if let states = taskState.value?.map(\.state) {
                 states.contains { [.subscribed, .inGracePeriod].contains($0) }
             } else {
@@ -111,10 +111,10 @@ public final class DonationSettings: Composable {
     }
 
     public enum Action: Sendable {
-        case task(String)
+        case viewAppeared(String)
         case restoreSubscriptionButtonTapped
-        case onReceiveProductTaskState(Product.CollectionTaskState)
-        case onPurchaseCompleted(Product, Result<Product.PurchaseResult, any Error>)
-        case onReceiveSubscriptionTaskState(EntitlementTaskState<[Product.SubscriptionInfo.Status]>)
+        case productTaskStateChanged(Product.CollectionTaskState)
+        case purchaseResponse(Product, Result<Product.PurchaseResult, any Error>)
+        case subscriptionTaskStateChanged(EntitlementTaskState<[Product.SubscriptionInfo.Status]>)
     }
 }

--- a/LocalPackage/Sources/Model/Stores/GeneralSettings.swift
+++ b/LocalPackage/Sources/Model/Stores/GeneralSettings.swift
@@ -49,10 +49,10 @@ public final class GeneralSettings: Composable {
 
     public func reduce(_ action: Action) async {
         switch action {
-        case let .task(screenName):
+        case let .viewAppeared(screenName):
             logService.notice(.screenView(name: screenName))
 
-        case let .updateIntervalChanged(interval):
+        case let .updateIntervalPickerSelected(interval):
             updateInterval = interval
             userDefaultsRepository.updateInterval = interval
             systemMetricsService.stopMonitoring()
@@ -69,8 +69,8 @@ public final class GeneralSettings: Composable {
     }
 
     public enum Action: Sendable {
-        case task(String)
-        case updateIntervalChanged(UpdateInterval)
+        case viewAppeared(String)
+        case updateIntervalPickerSelected(UpdateInterval)
         case launchAtLoginToggleSwitched(Bool)
     }
 }

--- a/LocalPackage/Sources/Model/Stores/MetricsBar.swift
+++ b/LocalPackage/Sources/Model/Stores/MetricsBar.swift
@@ -57,7 +57,7 @@ public final class MetricsBar: Composable {
 
     public func reduce(_ action: Action) async {
         switch action {
-        case let .task(screenName):
+        case let .viewAppeared(screenName):
             logService.notice(.screenView(name: screenName))
             if let metrics = appStateClient.withLock(\.metrics.latestValue) {
                 updateMetrics(from: metrics)
@@ -86,7 +86,7 @@ public final class MetricsBar: Composable {
                 }
             }
 
-        case .onDisappear:
+        case .viewDisappeared:
             task?.cancel()
             task = nil
         }
@@ -102,7 +102,7 @@ public final class MetricsBar: Composable {
     }
 
     public enum Action: Sendable {
-        case task(String)
-        case onDisappear
+        case viewAppeared(String)
+        case viewDisappeared
     }
 }

--- a/LocalPackage/Sources/Model/Stores/MetricsBarSettings.swift
+++ b/LocalPackage/Sources/Model/Stores/MetricsBarSettings.swift
@@ -53,7 +53,7 @@ public final class MetricsBarSettings: Composable {
 
     public func reduce(_ action: Action) async {
         switch action {
-        case let .task(screenName):
+        case let .viewAppeared(screenName):
             logService.notice(.screenView(name: screenName))
             metricsBarConfiguration = userDefaultsRepository.metricsBarConfiguration
             customMetricsSources = userDefaultsRepository.customMetricsConfiguration.sources
@@ -65,7 +65,7 @@ public final class MetricsBarSettings: Composable {
                 }
             }
 
-        case .onDisappear:
+        case .viewDisappeared:
             task?.cancel()
             task = nil
 
@@ -120,8 +120,8 @@ public final class MetricsBarSettings: Composable {
     }
 
     public enum Action: Sendable {
-        case task(String)
-        case onDisappear
+        case viewAppeared(String)
+        case viewDisappeared
         case showsSystemMetricsToggleSwitched(SystemInfoType, Bool)
         case showsCustomMetricsToggleSwitched(UUID, Bool)
     }

--- a/LocalPackage/Sources/Model/Stores/MetricsSettings.swift
+++ b/LocalPackage/Sources/Model/Stores/MetricsSettings.swift
@@ -72,7 +72,7 @@ public final class MetricsSettings: Composable {
 
     public func reduce(_ action: Action) async {
         switch action {
-        case let .task(screenName):
+        case let .viewAppeared(screenName):
             logService.notice(.screenView(name: screenName))
             task?.cancel()
             task = Task.immediate { [weak self, appStateClient] in
@@ -82,7 +82,7 @@ public final class MetricsSettings: Composable {
                 }
             }
 
-        case .onDisappear:
+        case .viewDisappeared:
             task?.cancel()
             task = nil
 
@@ -128,7 +128,7 @@ public final class MetricsSettings: Composable {
             systemMetricsService.toggleSystemMetricsActivation(type: type, isOn: isOn)
             systemMetricsService.emitConfigurationChange()
 
-        case let .customMetricsSettings(.onError(error)):
+        case let .customMetricsSettings(.errorOccurred(error)):
             self.error = error
             showingAlert = true
 
@@ -142,8 +142,8 @@ public final class MetricsSettings: Composable {
     }
 
     public enum Action: Sendable {
-        case task(String)
-        case onDisappear
+        case viewAppeared(String)
+        case viewDisappeared
         case showMetricsBarToggleSwitched(Bool)
         case changedMyMindButtonTapped
         case showButtonTapped

--- a/LocalPackage/Sources/Model/Stores/RunnerBar.swift
+++ b/LocalPackage/Sources/Model/Stores/RunnerBar.swift
@@ -59,7 +59,7 @@ public final class RunnerBar: Composable {
 
     public func reduce(_ action: Action) async {
         switch action {
-        case let .task(screenName, eventBridge):
+        case let .viewAppeared(screenName, eventBridge):
             logService.notice(.screenView(name: screenName))
             self.eventBridge = eventBridge
             task?.cancel()
@@ -85,7 +85,7 @@ public final class RunnerBar: Composable {
                 }
             }
 
-        case .onDisappear:
+        case .viewDisappeared:
             task?.cancel()
             task = nil
         }
@@ -134,8 +134,8 @@ public final class RunnerBar: Composable {
     }
 
     public enum Action: Sendable {
-        case task(String, EventBridge)
-        case onDisappear
+        case viewAppeared(String, EventBridge)
+        case viewDisappeared
 
         public struct EventBridge: Sendable {
             public let getBundleImage: @MainActor @Sendable (String) -> NSImage

--- a/LocalPackage/Sources/Model/Stores/RunnerSettings.swift
+++ b/LocalPackage/Sources/Model/Stores/RunnerSettings.swift
@@ -61,7 +61,7 @@ public final class RunnerSettings: Composable {
 
     public func reduce(_ action: Action) async {
         switch action {
-        case let .task(screenName):
+        case let .viewAppeared(screenName):
             logService.notice(.screenView(name: screenName))
 
         case let .slowDownUnderLoadToggleSwitched(isOn):
@@ -75,7 +75,7 @@ public final class RunnerSettings: Composable {
             userDefaultsRepository.isFlippedHorizontally = isOn
             runnerService.resendCurrentRunnerBundle()
 
-        case let .customRunnerSettings(.onError(error)):
+        case let .customRunnerSettings(.errorOccurred(error)):
             self.error = error
             showingAlert = true
 
@@ -85,7 +85,7 @@ public final class RunnerSettings: Composable {
     }
 
     public enum Action: Sendable {
-        case task(String)
+        case viewAppeared(String)
         case slowDownUnderLoadToggleSwitched(Bool)
         case flipHorizontallyToggleSwitched(Bool)
         case customRunnerSettings(CustomRunnerSettings.Action)

--- a/LocalPackage/Sources/UserInterface/Views/MetricsBar/MetricsBarSettingsView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/MetricsBar/MetricsBarSettingsView.swift
@@ -80,11 +80,11 @@ struct MetricsBarSettingsView: View {
         .frame(width: 360)
         .fixedSize()
         .task {
-            await store.send(.task(String(describing: Self.self)))
+            await store.send(.viewAppeared(String(describing: Self.self)))
         }
         .onDisappear {
             Task {
-                await store.send(.onDisappear)
+                await store.send(.viewDisappeared)
             }
         }
     }

--- a/LocalPackage/Sources/UserInterface/Views/MetricsBar/MetricsBarView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/MetricsBar/MetricsBarView.swift
@@ -90,7 +90,7 @@ struct MetricsBarView: View {
         }
         .renderingMode(.template)
         .task {
-            await store.send(.task(String(describing: Self.self)))
+            await store.send(.viewAppeared(String(describing: Self.self)))
         }
     }
 

--- a/LocalPackage/Sources/UserInterface/Views/RunnerBar/Dashboard/DashboardView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/RunnerBar/Dashboard/DashboardView.swift
@@ -50,11 +50,11 @@ struct DashboardView: View {
         .fixedSize()
         .padding(8)
         .task {
-            await store.send(.task(String(describing: Self.self)))
+            await store.send(.viewAppeared(String(describing: Self.self)))
         }
         .onDisappear {
             Task {
-                await store.send(.onDisappear)
+                await store.send(.viewDisappeared)
             }
         }
     }

--- a/LocalPackage/Sources/UserInterface/Views/RunnerBar/RunnerBarView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/RunnerBar/RunnerBarView.swift
@@ -70,7 +70,7 @@ struct RunnerBarView: View {
             let runnerLayer = RunnerLayer(gap: gap)
             statusBarButton.layer?.addSublayer(runnerLayer)
             StatusBarAppearanceBridge.shared.send(window.effectiveAppearance)
-            await store.send(.task(
+            await store.send(.viewAppeared(
                 String(describing: Self.self),
                 .init(
                     getBundleImage: { NSImage(resource: .init(name: $0, bundle: .module)) },
@@ -85,7 +85,7 @@ struct RunnerBarView: View {
         // but I am including it here for the sake of formality.
         .onDisappear {
             Task {
-                await store.send(.onDisappear)
+                await store.send(.viewDisappeared)
             }
         }
     }

--- a/LocalPackage/Sources/UserInterface/Views/Settings/DonationSettingsView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/Settings/DonationSettingsView.swift
@@ -103,16 +103,16 @@ struct DonationSettingsView: View {
             message: { _ in }
         )
         .task {
-            await store.send(.task(String(describing: Self.self)))
+            await store.send(.viewAppeared(String(describing: Self.self)))
         }
         .storeProductsTask(for: DonationProduct.allCases.map(\.id)) { taskState in
-            await store.send(.onReceiveProductTaskState(taskState))
+            await store.send(.productTaskStateChanged(taskState))
         }
         .onInAppPurchaseCompletion { product, result in
-            await store.send(.onPurchaseCompleted(product, result))
+            await store.send(.purchaseResponse(product, result))
         }
         .subscriptionStatusTask(for: store.subscriptionGroupID) { taskState in
-            await store.send(.onReceiveSubscriptionTaskState(taskState))
+            await store.send(.subscriptionTaskStateChanged(taskState))
         }
     }
 }

--- a/LocalPackage/Sources/UserInterface/Views/Settings/GeneralSettingsView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/Settings/GeneralSettingsView.swift
@@ -40,7 +40,7 @@ struct GeneralSettingsView: View {
             Section {
                 Picker(selection: Binding<UpdateInterval>(
                     get: { store.updateInterval },
-                    asyncSet: { await store.send(.updateIntervalChanged($0)) }
+                    asyncSet: { await store.send(.updateIntervalPickerSelected($0)) }
                 )) {
                     ForEach(UpdateInterval.allCases) { interval in
                         Text("\(interval.seconds)seconds", bundle: .module)
@@ -55,7 +55,7 @@ struct GeneralSettingsView: View {
         }
         .formStyle(.grouped)
         .task {
-            await store.send(.task(String(describing: Self.self)))
+            await store.send(.viewAppeared(String(describing: Self.self)))
         }
     }
 }

--- a/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSettingsSectionView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/CustomMetricsSettingsSectionView.swift
@@ -41,7 +41,7 @@ struct CustomMetricsSettingsSectionView: View {
                 }
                 .onMove { indexSet, offset in
                     Task {
-                        await store.send(.onMoveCustomMetricsSourceRow(indexSet, offset))
+                        await store.send(.customMetricsSourceRowMoved(indexSet, offset))
                     }
                 }
             }
@@ -87,7 +87,7 @@ struct CustomMetricsSettingsSectionView: View {
                 allowsMultipleSelection: false,
                 onCompletion: { result in
                     Task {
-                        await store.send(.onCompletionFileImporter(result))
+                        await store.send(.fileImporterResponse(result))
                     }
                 }
             )
@@ -121,11 +121,11 @@ struct CustomMetricsSettingsSectionView: View {
             Text("customMetrics", bundle: .module)
         }
         .task {
-            await store.send(.task)
+            await store.send(.viewAppeared)
         }
         .onDisappear {
             Task {
-                await store.send(.onDisappear)
+                await store.send(.viewDisappeared)
             }
         }
     }

--- a/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/MetricsSettingsView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/Settings/MetricsSettings/MetricsSettingsView.swift
@@ -77,11 +77,11 @@ struct MetricsSettingsView: View {
             message: { _ in }
         )
         .task {
-            await store.send(.task(String(describing: Self.self)))
+            await store.send(.viewAppeared(String(describing: Self.self)))
         }
         .onDisappear {
             Task {
-                await store.send(.onDisappear)
+                await store.send(.viewDisappeared)
             }
         }
     }

--- a/LocalPackage/Sources/UserInterface/Views/Settings/RunnerSettings/CustomRunnerEditorView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/Settings/RunnerSettings/CustomRunnerEditorView.swift
@@ -35,7 +35,7 @@ struct CustomRunnerEditorView: View {
                     .textFieldStyle(.roundedBorder)
                     Picker(selection: Binding<RenderingMode>(
                         get: { .init(isTemplate: store.isTemplate) },
-                        asyncSet: { await store.send(.selectRenderingMode($0)) }
+                        asyncSet: { await store.send(.renderingModePickerSelected($0)) }
                     )) {
                         ForEach(RenderingMode.allCases) { mode in
                             Text(mode.label).tag(mode)
@@ -66,7 +66,7 @@ struct CustomRunnerEditorView: View {
                 allowsMultipleSelection: true,
                 onCompletion: { result in
                     Task {
-                        await store.send(.onCompletionFileImporter(result))
+                        await store.send(.fileImporterResponse(result))
                     }
                 }
             )

--- a/LocalPackage/Sources/UserInterface/Views/Settings/RunnerSettings/CustomRunnerSettingsSectionView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/Settings/RunnerSettings/CustomRunnerSettingsSectionView.swift
@@ -46,7 +46,7 @@ struct CustomRunnerSettingsSectionView: View {
                 }
                 .onMove { indexSet, offset in
                     Task {
-                        await store.send(.onMoveCustomRunnerRow(indexSet, offset))
+                        await store.send(.customRunnerRowMoved(indexSet, offset))
                     }
                 }
             }
@@ -65,7 +65,7 @@ struct CustomRunnerSettingsSectionView: View {
                 }
                 .sheet(isPresented: $store.showingCustomRunnerEditorSheet) {
                     Task {
-                        await store.send(.onDissmissSheet)
+                        await store.send(.sheetDismissed)
                     }
                 } content: {
                     CustomRunnerEditorView(store: store)
@@ -81,11 +81,11 @@ struct CustomRunnerSettingsSectionView: View {
                 .fixedSize()
         }
         .task {
-            await store.send(.task)
+            await store.send(.viewAppeared)
         }
         .onDisappear {
             Task {
-                await store.send(.onDisappear)
+                await store.send(.viewDisappeared)
             }
         }
     }

--- a/LocalPackage/Sources/UserInterface/Views/Settings/RunnerSettings/FrameImagesCollectionView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/Settings/RunnerSettings/FrameImagesCollectionView.swift
@@ -39,7 +39,7 @@ struct FrameImagesCollectionView: View {
                         )
                         .onTapGesture {
                             Task {
-                                await store.send(.onTapFrameImageCell(frameImage))
+                                await store.send(.frameImageCellTapped(frameImage))
                             }
                         }
                         .sortable(
@@ -54,12 +54,12 @@ struct FrameImagesCollectionView: View {
             .background(Color(.controlBackgroundColor))
             .onTapGesture {
                 Task {
-                    await store.send(.onTapCollectionBackground)
+                    await store.send(.collectionBackgroundTapped)
                 }
             }
             .dropDestination(for: URL.self) { urls, _ in
                 Task {
-                    await store.send(.onDropFiles(urls))
+                    await store.send(.filesDropped(urls))
                 }
                 return true
             }

--- a/LocalPackage/Sources/UserInterface/Views/Settings/RunnerSettings/RunnerSettingsView.swift
+++ b/LocalPackage/Sources/UserInterface/Views/Settings/RunnerSettings/RunnerSettingsView.swift
@@ -52,7 +52,7 @@ struct RunnerSettingsView: View {
             message: { _ in }
         )
         .task {
-            await store.send(.task(String(describing: Self.self)))
+            await store.send(.viewAppeared(String(describing: Self.self)))
         }
     }
 }

--- a/LocalPackage/Tests/ModelTests/StoreTests/CustomMetricsSettingsTests.swift
+++ b/LocalPackage/Tests/ModelTests/StoreTests/CustomMetricsSettingsTests.swift
@@ -12,7 +12,7 @@ struct CustomMetricsSettingsTests {
     ) {
         let lock = AllocatedUnfairLock<RCNError?>(initialState: nil)
         let action: (CustomMetricsSettings.Action) async -> Void = { action in
-            if case let .onError(error) = action {
+            if case let .errorOccurred(error) = action {
                 lock.withLock { $0 = error }
             }
         }
@@ -20,23 +20,23 @@ struct CustomMetricsSettingsTests {
     }
 
     @MainActor @Test
-    func send_task_refreshes_failed_source_ids_when_metrics_change() async {
+    func send_viewAppeared_refreshes_failed_source_ids_when_metrics_change() async {
         let appState = AllocatedUnfairLock<AppState>(initialState: .init())
         let snapshot = CustomMetricsSnapshot(title: "Card", lastUpdatedDate: Date(timeIntervalSince1970: 0))
         let failedBundle = CustomMetricsBundle(id: UUID(1), snapshot: snapshot, isFailed: true)
         appState.withLock { $0.metrics.send(Metrics(customMetricsBundles: [failedBundle])) }
         let sut = CustomMetricsSettings(.testDependencies(appStateClient: .testDependency(appState)))
-        await sut.send(.task)
+        await sut.send(.viewAppeared)
         #expect(sut.failedCustomMetricsSourceIDs == [UUID(1)])
         let recoveredBundle = CustomMetricsBundle(id: UUID(1), snapshot: snapshot, isFailed: false)
         appState.withLock { $0.metrics.send(Metrics(customMetricsBundles: [recoveredBundle])) }
         await waitUntil { sut.failedCustomMetricsSourceIDs.isEmpty }
         #expect(sut.failedCustomMetricsSourceIDs.isEmpty)
-        await sut.send(.onDisappear)
+        await sut.send(.viewDisappeared)
     }
 
     @MainActor @Test
-    func send_task_reloads_customMetricsSources_from_user_defaults() async {
+    func send_viewAppeared_reloads_customMetricsSources_from_user_defaults() async {
         let storage = UserDefaultsClient.storage(initialSources: [
             CustomMetricsSource(
                 id: UUID(1),
@@ -49,7 +49,7 @@ struct CustomMetricsSettingsTests {
         let sut = CustomMetricsSettings(.testDependencies(
             userDefaultsClient: storage.client
         ))
-        await sut.send(.task)
+        await sut.send(.viewAppeared)
         #expect(sut.customMetricsSources.count == 1)
         #expect(sut.customMetricsSources.first?.displayName == "Existing")
     }
@@ -69,7 +69,7 @@ struct CustomMetricsSettingsTests {
         let sut = CustomMetricsSettings(.testDependencies(
             userDefaultsClient: storage.client
         ))
-        await sut.send(.task)
+        await sut.send(.viewAppeared)
         await sut.send(.removeCustomMetricsSourceButtonTapped(existingID))
         #expect(sut.pendingRemovalSourceID == existingID)
         #expect(sut.showingConfirmationDialog == true)
@@ -177,7 +177,7 @@ struct CustomMetricsSettingsTests {
     }
 
     @MainActor @Test
-    func send_onMoveCustomMetricsSourceRow_reorders_sources_and_emits_change() async {
+    func send_customMetricsSourceRowMoved_reorders_sources_and_emits_change() async {
         let appState = AllocatedUnfairLock<AppState>(initialState: .init())
         let storage = UserDefaultsClient.storage(initialSources: [
             CustomMetricsSource(
@@ -199,7 +199,7 @@ struct CustomMetricsSettingsTests {
             appStateClient: .testDependency(appState),
             userDefaultsClient: storage.client
         ))
-        await sut.send(.onMoveCustomMetricsSourceRow(IndexSet(integer: 1), 0))
+        await sut.send(.customMetricsSourceRowMoved(IndexSet(integer: 1), 0))
         #expect(sut.customMetricsSources.map(\.id) == [UUID(10), UUID(9)])
         #expect(storage.currentConfiguration()?.sources.map(\.id) == [UUID(10), UUID(9)])
         #expect(appState.withLock(\.customMetricsConfigurationChanges.latestValue) != nil)
@@ -220,7 +220,7 @@ struct CustomMetricsSettingsTests {
     }
 
     @MainActor @Test
-    func send_onCompletionFileImporter_success_appends_source_and_emits_change() async {
+    func send_fileImporterResponse_success_appends_source_and_emits_change() async {
         let appState = AllocatedUnfairLock<AppState>(initialState: .init())
         let storage = UserDefaultsClient.storage()
         let fileURL = URL(filePath: "/tmp/metrics.json")
@@ -239,7 +239,7 @@ struct CustomMetricsSettingsTests {
             urlClient: urlClient,
             userDefaultsClient: storage.client
         ))
-        await sut.send(.onCompletionFileImporter(.success([fileURL])))
+        await sut.send(.fileImporterResponse(.success([fileURL])))
         #expect(sut.customMetricsSources.count == 1)
         #expect(sut.customMetricsSources.first?.displayName == "Imported")
         #expect(sut.customMetricsSources.first?.bookmark == Data([0xAB]))
@@ -247,7 +247,7 @@ struct CustomMetricsSettingsTests {
     }
 
     @MainActor @Test
-    func send_onCompletionFileImporter_forwards_error_when_file_is_unreadable() async {
+    func send_fileImporterResponse_forwards_error_when_file_is_unreadable() async {
         let storage = UserDefaultsClient.storage()
         let recorder = errorRecorder()
         let sut = CustomMetricsSettings(
@@ -262,13 +262,13 @@ struct CustomMetricsSettingsTests {
             ),
             action: recorder.action
         )
-        await sut.send(.onCompletionFileImporter(.success([URL(filePath: "/tmp/metrics.json")])))
+        await sut.send(.fileImporterResponse(.success([URL(filePath: "/tmp/metrics.json")])))
         #expect(recorder.lock.withLock(\.self) == .customMetrics(.fileUnreadable))
         #expect(sut.customMetricsSources.isEmpty)
     }
 
     @MainActor @Test
-    func send_onCompletionFileImporter_forwards_error_when_json_is_invalid() async {
+    func send_fileImporterResponse_forwards_error_when_json_is_invalid() async {
         let storage = UserDefaultsClient.storage()
         let recorder = errorRecorder()
         let sut = CustomMetricsSettings(
@@ -283,32 +283,32 @@ struct CustomMetricsSettingsTests {
             ),
             action: recorder.action
         )
-        await sut.send(.onCompletionFileImporter(.success([URL(filePath: "/tmp/metrics.json")])))
+        await sut.send(.fileImporterResponse(.success([URL(filePath: "/tmp/metrics.json")])))
         #expect(recorder.lock.withLock(\.self) == .customMetrics(.invalidFormat))
         #expect(sut.customMetricsSources.isEmpty)
     }
 
     @MainActor @Test
-    func send_onCompletionFileImporter_success_without_url_is_noop() async {
+    func send_fileImporterResponse_success_without_url_is_noop() async {
         let appState = AllocatedUnfairLock<AppState>(initialState: .init())
         let storage = UserDefaultsClient.storage()
         let sut = CustomMetricsSettings(.testDependencies(
             appStateClient: .testDependency(appState),
             userDefaultsClient: storage.client
         ))
-        await sut.send(.onCompletionFileImporter(.success([])))
+        await sut.send(.fileImporterResponse(.success([])))
         #expect(sut.customMetricsSources.isEmpty)
         #expect(appState.withLock(\.customMetricsConfigurationChanges.latestValue) == nil)
     }
 
     @MainActor @Test
-    func send_onCompletionFileImporter_failure_does_not_throw() async {
+    func send_fileImporterResponse_failure_does_not_throw() async {
         struct DummyError: Error {}
         let storage = UserDefaultsClient.storage()
         let sut = CustomMetricsSettings(.testDependencies(
             userDefaultsClient: storage.client
         ))
-        await sut.send(.onCompletionFileImporter(.failure(DummyError())))
+        await sut.send(.fileImporterResponse(.failure(DummyError())))
         #expect(sut.customMetricsSources.isEmpty)
     }
 
@@ -327,7 +327,7 @@ struct CustomMetricsSettingsTests {
         let sut = CustomMetricsSettings(.testDependencies(
             userDefaultsClient: storage.client
         ))
-        await sut.send(.task)
+        await sut.send(.viewAppeared)
         await sut.send(.removeCustomMetricsSourceButtonTapped(existingID))
         await sut.send(.removingCustomMetricsSourceConfirmed)
         #expect(sut.customMetricsSources.isEmpty)
@@ -349,7 +349,7 @@ struct CustomMetricsSettingsTests {
         let sut = CustomMetricsSettings(.testDependencies(
             userDefaultsClient: storage.client
         ))
-        await sut.send(.task)
+        await sut.send(.viewAppeared)
         await sut.send(.removingCustomMetricsSourceConfirmed)
         #expect(sut.customMetricsSources.count == 1)
     }
@@ -369,7 +369,7 @@ struct CustomMetricsSettingsTests {
         let sut = CustomMetricsSettings(.testDependencies(
             userDefaultsClient: storage.client
         ))
-        await sut.send(.task)
+        await sut.send(.viewAppeared)
         await sut.send(.removeCustomMetricsSourceButtonTapped(existingID))
         await sut.send(.removingCustomMetricsSourceCancelled)
         #expect(sut.pendingRemovalSourceID == nil)

--- a/LocalPackage/Tests/ModelTests/StoreTests/CustomRunnerSettingsTests.swift
+++ b/LocalPackage/Tests/ModelTests/StoreTests/CustomRunnerSettingsTests.swift
@@ -16,7 +16,7 @@ struct CustomRunnerSettingsTests {
     ) {
         let lock = AllocatedUnfairLock<RCNError?>(initialState: nil)
         let action: (CustomRunnerSettings.Action) async -> Void = { action in
-            if case let .onError(error) = action {
+            if case let .errorOccurred(error) = action {
                 lock.withLock { $0 = error }
             }
         }
@@ -24,7 +24,7 @@ struct CustomRunnerSettingsTests {
     }
 
     @MainActor @Test
-    func send_task_filters_custom_runners_and_starts_frame_preview() async {
+    func send_viewAppeared_filters_custom_runners_and_starts_frame_preview() async {
         let appState = AllocatedUnfairLock<AppState>(initialState: .init())
         let customBundle = RunnerBundle(runner: customRunner, frame: .custom(Data()))
         appState.withLock {
@@ -38,11 +38,11 @@ struct CustomRunnerSettingsTests {
             .testDependencies(appStateClient: .testDependency(appState)),
             frameImages: frameImages
         )
-        await sut.send(.task)
+        await sut.send(.viewAppeared)
         let previewedSecondFrameImage = await waitUntil { sut.previewingFrameImage == frameImages[1] }
         #expect(sut.customRunnerBundleList == [customBundle])
         #expect(previewedSecondFrameImage)
-        await sut.send(.onDisappear)
+        await sut.send(.viewDisappeared)
     }
 
     @MainActor @Test
@@ -79,7 +79,7 @@ struct CustomRunnerSettingsTests {
     }
 
     @MainActor @Test
-    func send_onMoveCustomRunnerRow_reorders_list_and_persists_new_order() async {
+    func send_customRunnerRowMoved_reorders_list_and_persists_new_order() async {
         let json = """
             [
               {
@@ -121,7 +121,7 @@ struct CustomRunnerSettingsTests {
             ),
             customRunnerBundleList: [firstBundle, secondBundle]
         )
-        await sut.send(.onMoveCustomRunnerRow(IndexSet(integer: 1), 0))
+        await sut.send(.customRunnerRowMoved(IndexSet(integer: 1), 0))
         #expect(sut.customRunnerBundleList == [secondBundle, firstBundle])
         let expectedJSON = #"[{"frameOrder":[0],"id":"second-runner","isTemplate":false,"name":"Second Runner"},"#
             + #"{"frameOrder":[0],"id":"first-runner","isTemplate":false,"name":"First Runner"}]"#
@@ -146,7 +146,7 @@ struct CustomRunnerSettingsTests {
     }
 
     @MainActor @Test
-    func send_onDissmissSheet_resets_editor_inputs() async {
+    func send_sheetDismissed_resets_editor_inputs() async {
         let frameImage = FrameImage.dummy()
         let sut = CustomRunnerSettings(
             .testDependencies(),
@@ -157,7 +157,7 @@ struct CustomRunnerSettingsTests {
             previewingFrameImage: frameImage,
             previewSpeed: 2
         )
-        await sut.send(.onDissmissSheet)
+        await sut.send(.sheetDismissed)
         #expect(sut.runnerName.isEmpty)
         #expect(sut.isTemplate == true)
         #expect(sut.frameImages.isEmpty)
@@ -167,29 +167,29 @@ struct CustomRunnerSettingsTests {
     }
 
     @MainActor @Test
-    func send_selectRenderingMode_updates_isTemplate() async {
+    func send_renderingModePickerSelected_updates_isTemplate() async {
         let sut = CustomRunnerSettings(.testDependencies())
-        await sut.send(.selectRenderingMode(.color))
+        await sut.send(.renderingModePickerSelected(.color))
         #expect(sut.isTemplate == false)
-        await sut.send(.selectRenderingMode(.monochrome))
+        await sut.send(.renderingModePickerSelected(.monochrome))
         #expect(sut.isTemplate == true)
     }
 
     @MainActor @Test
-    func send_onTapFrameImageCell_selects_frame_and_background_clears_it() async {
+    func send_frameImageCellTapped_selects_frame_and_background_clears_it() async {
         let frameImage = FrameImage.dummy()
         let sut = CustomRunnerSettings(.testDependencies())
-        await sut.send(.onTapFrameImageCell(frameImage))
+        await sut.send(.frameImageCellTapped(frameImage))
         #expect(sut.selectingFrameImage == frameImage)
-        await sut.send(.onTapCollectionBackground)
+        await sut.send(.collectionBackgroundTapped)
         #expect(sut.selectingFrameImage == nil)
     }
 
     @MainActor @Test
-    func send_onDropFiles_appends_valid_png_and_ignores_other_extensions() async {
+    func send_filesDropped_appends_valid_png_and_ignores_other_extensions() async {
         let recorder = errorRecorder()
         let sut = CustomRunnerSettings(.testDependencies(), action: recorder.action)
-        await sut.send(.onDropFiles([
+        await sut.send(.filesDropped([
             URL.fixture(name: "solid_red_30x36"),
             URL(filePath: "/tmp/ignored.json"),
         ]))
@@ -198,10 +198,10 @@ struct CustomRunnerSettingsTests {
     }
 
     @MainActor @Test
-    func send_onDropFiles_forwards_error_when_image_size_is_invalid() async {
+    func send_filesDropped_forwards_error_when_image_size_is_invalid() async {
         let recorder = errorRecorder()
         let sut = CustomRunnerSettings(.testDependencies(), action: recorder.action)
-        await sut.send(.onDropFiles([URL.fixture(name: "solid_red_10x18")]))
+        await sut.send(.filesDropped([URL.fixture(name: "solid_red_10x18")]))
         #expect(recorder.lock.withLock(\.self) == .customRunner(.invalidFrameImage))
         #expect(sut.frameImages.isEmpty)
     }
@@ -228,7 +228,7 @@ struct CustomRunnerSettingsTests {
     }
 
     @MainActor @Test
-    func send_onCompletionFileImporter_appends_accessible_frame_image() async {
+    func send_fileImporterResponse_appends_accessible_frame_image() async {
         let recorder = errorRecorder()
         let urlClient = testDependency(of: URLClient.self) {
             $0.startAccessingSecurityScopedResource = { _ in true }
@@ -238,13 +238,13 @@ struct CustomRunnerSettingsTests {
             .testDependencies(urlClient: urlClient),
             action: recorder.action
         )
-        await sut.send(.onCompletionFileImporter(.success([URL.fixture(name: "solid_red_30x36")])))
+        await sut.send(.fileImporterResponse(.success([URL.fixture(name: "solid_red_30x36")])))
         #expect(sut.frameImages.count == 1)
         #expect(recorder.lock.withLock(\.self) == nil)
     }
 
     @MainActor @Test
-    func send_onCompletionFileImporter_skips_inaccessible_frame_image() async {
+    func send_fileImporterResponse_skips_inaccessible_frame_image() async {
         let recorder = errorRecorder()
         let urlClient = testDependency(of: URLClient.self) {
             $0.startAccessingSecurityScopedResource = { _ in false }
@@ -253,16 +253,16 @@ struct CustomRunnerSettingsTests {
             .testDependencies(urlClient: urlClient),
             action: recorder.action
         )
-        await sut.send(.onCompletionFileImporter(.success([URL.fixture(name: "solid_red_30x36")])))
+        await sut.send(.fileImporterResponse(.success([URL.fixture(name: "solid_red_30x36")])))
         #expect(sut.frameImages.isEmpty)
         #expect(recorder.lock.withLock(\.self) == nil)
     }
 
     @MainActor @Test
-    func send_onCompletionFileImporter_failure_is_noop() async {
+    func send_fileImporterResponse_failure_is_noop() async {
         let recorder = errorRecorder()
         let sut = CustomRunnerSettings(.testDependencies(), action: recorder.action)
-        await sut.send(.onCompletionFileImporter(.failure(URLError(.cancelled))))
+        await sut.send(.fileImporterResponse(.failure(URLError(.cancelled))))
         #expect(sut.frameImages.isEmpty)
         #expect(recorder.lock.withLock(\.self) == nil)
     }

--- a/LocalPackage/Tests/ModelTests/StoreTests/DashboardTests.swift
+++ b/LocalPackage/Tests/ModelTests/StoreTests/DashboardTests.swift
@@ -8,22 +8,22 @@ import Testing
 
 struct DashboardTests {
     @MainActor @Test
-    func send_task_loads_latest_metrics_and_observes_stream() async {
+    func send_viewAppeared_loads_latest_metrics_and_observes_stream() async {
         let appState = AllocatedUnfairLock<AppState>(initialState: .init())
         let initialMetrics = Metrics.dummy(customMetricsTitle: "Initial")
         appState.withLock { $0.metrics.send(initialMetrics) }
         let sut = Dashboard(.testDependencies(appStateClient: .testDependency(appState)))
-        await sut.send(.task("DashboardTests"))
+        await sut.send(.viewAppeared("DashboardTests"))
         #expect(sut.customMetricsBundles == initialMetrics.customMetricsBundles)
         let updatedMetrics = Metrics.dummy(customMetricsTitle: "Updated")
         appState.withLock { $0.metrics.send(updatedMetrics) }
         await waitUntil { sut.customMetricsBundles == updatedMetrics.customMetricsBundles }
         #expect(sut.customMetricsBundles == updatedMetrics.customMetricsBundles)
-        await sut.send(.onDisappear)
+        await sut.send(.viewDisappeared)
     }
 
     @MainActor @Test
-    func send_task_refreshes_displayedDate_every_time_it_is_sent() async {
+    func send_viewAppeared_refreshes_displayedDate_every_time_it_is_sent() async {
         let dates = AllocatedUnfairLock<[Date]>(initialState: [
             Date(timeIntervalSince1970: 1_000),
             Date(timeIntervalSince1970: 2_000),
@@ -37,23 +37,23 @@ struct DashboardTests {
             displayedDate: .distantPast
         )
         #expect(sut.displayedDate == .distantPast)
-        await sut.send(.task("DashboardTests"))
+        await sut.send(.viewAppeared("DashboardTests"))
         #expect(sut.displayedDate == Date(timeIntervalSince1970: 1_000))
-        await sut.send(.onDisappear)
-        await sut.send(.task("DashboardTests"))
+        await sut.send(.viewDisappeared)
+        await sut.send(.viewAppeared("DashboardTests"))
         #expect(sut.displayedDate == Date(timeIntervalSince1970: 2_000))
-        await sut.send(.onDisappear)
+        await sut.send(.viewDisappeared)
     }
 
     @MainActor @Test
-    func send_task_loads_current_runner_and_runner_bundle_list_then_observes_streams() async {
+    func send_viewAppeared_loads_current_runner_and_runner_bundle_list_then_observes_streams() async {
         let appState = AllocatedUnfairLock<AppState>(initialState: .init())
         appState.withLock {
             $0.runnerBundles.send(RunnerBundle(runner: .default, frame: .preset("cat-frame-0")))
             $0.runnerBundleLists.send([RunnerBundle(runner: .default, frame: .preset("cat-frame-0"))])
         }
         let sut = Dashboard(.testDependencies(appStateClient: .testDependency(appState)))
-        await sut.send(.task("DashboardTests"))
+        await sut.send(.viewAppeared("DashboardTests"))
         #expect(sut.currentRunner == Runner.default)
         #expect(sut.runnerBundleList.map(\.runner) == [Runner.default])
         appState.withLock {
@@ -63,26 +63,26 @@ struct DashboardTests {
         await waitUntil { sut.currentRunner == Runner(kind: .dog) }
         #expect(sut.currentRunner == Runner(kind: .dog))
         #expect(sut.runnerBundleList.map(\.runner) == [Runner(kind: .dog)])
-        await sut.send(.onDisappear)
+        await sut.send(.viewDisappeared)
     }
 
     @MainActor @Test
-    func send_onDisappear_stops_observing_metrics() async {
+    func send_viewDisappeared_stops_observing_metrics() async {
         let appState = AllocatedUnfairLock<AppState>(initialState: .init())
         let sut = Dashboard(.testDependencies(appStateClient: .testDependency(appState)))
-        await sut.send(.task("DashboardTests"))
-        await sut.send(.onDisappear)
+        await sut.send(.viewAppeared("DashboardTests"))
+        await sut.send(.viewDisappeared)
         appState.withLock { $0.metrics.send(.dummy(customMetricsTitle: "Ignored")) }
         try? await Task.sleep(for: .milliseconds(50))
         #expect(sut.customMetricsBundles.isEmpty)
     }
 
     @MainActor @Test
-    func send_onDisappear_stops_observing_runner_streams() async {
+    func send_viewDisappeared_stops_observing_runner_streams() async {
         let appState = AllocatedUnfairLock<AppState>(initialState: .init())
         let sut = Dashboard(.testDependencies(appStateClient: .testDependency(appState)))
-        await sut.send(.task("DashboardTests"))
-        await sut.send(.onDisappear)
+        await sut.send(.viewAppeared("DashboardTests"))
+        await sut.send(.viewDisappeared)
         appState.withLock {
             $0.runnerBundles.send(RunnerBundle(runner: .default, frame: .preset("cat-frame-0")))
         }

--- a/LocalPackage/Tests/ModelTests/StoreTests/DonationSettingsTests.swift
+++ b/LocalPackage/Tests/ModelTests/StoreTests/DonationSettingsTests.swift
@@ -6,12 +6,12 @@ import Testing
 
 struct DonationSettingsTests {
     @MainActor @Test
-    func send_task_forwards_action_to_parent() async {
+    func send_viewAppeared_forwards_action_to_parent() async {
         let receivedActionCount = AllocatedUnfairLock<Int>(initialState: 0)
         let sut = DonationSettings(.testDependencies()) { _ in
             receivedActionCount.withLock { $0 += 1 }
         }
-        await sut.send(.task("DonationSettingsTests"))
+        await sut.send(.viewAppeared("DonationSettingsTests"))
         #expect(receivedActionCount.withLock(\.self) == 1)
     }
 

--- a/LocalPackage/Tests/ModelTests/StoreTests/GeneralSettingsTests.swift
+++ b/LocalPackage/Tests/ModelTests/StoreTests/GeneralSettingsTests.swift
@@ -7,7 +7,7 @@ import Testing
 
 struct GeneralSettingsTests {
     @MainActor @Test
-    func send_updateIntervalChanged_persists_and_restarts_monitoring() async {
+    func send_updateIntervalPickerSelected_persists_and_restarts_monitoring() async {
         let setCallStack = AllocatedUnfairLock<[String]>(initialState: [])
         let monitoringEvents = AllocatedUnfairLock<[String]>(initialState: [])
         let sut = GeneralSettings(.testDependencies(
@@ -27,7 +27,7 @@ struct GeneralSettingsTests {
                 }
             }
         ))
-        await sut.send(.updateIntervalChanged(.threeSeconds))
+        await sut.send(.updateIntervalPickerSelected(.threeSeconds))
         #expect(sut.updateInterval == .threeSeconds)
         #expect(setCallStack.withLock(\.self) == ["set: UPDATE_INTERVAL = 3"])
         #expect(monitoringEvents.withLock(\.self) == ["stop", "start: 3.0"])

--- a/LocalPackage/Tests/ModelTests/StoreTests/MetricsBarSettingsTests.swift
+++ b/LocalPackage/Tests/ModelTests/StoreTests/MetricsBarSettingsTests.swift
@@ -19,7 +19,7 @@ struct MetricsBarSettingsTests {
     }
 
     @MainActor @Test
-    func send_task_loads_customMetricsSources_from_user_defaults() async {
+    func send_viewAppeared_loads_customMetricsSources_from_user_defaults() async {
         let appState = AllocatedUnfairLock<AppState>(initialState: .init())
         let source = makeSource(id: UUID(1))
         let storage = UserDefaultsClient.storage(initialSources: [source])
@@ -27,20 +27,20 @@ struct MetricsBarSettingsTests {
             appStateClient: .testDependency(appState),
             userDefaultsClient: storage.client
         ))
-        await sut.send(.task("MetricsBarSettingsTests"))
+        await sut.send(.viewAppeared("MetricsBarSettingsTests"))
         #expect(sut.customMetricsSources == [source])
-        await sut.send(.onDisappear)
+        await sut.send(.viewDisappeared)
     }
 
     @MainActor @Test
-    func send_task_refreshes_sources_when_custom_metrics_configuration_change_is_emitted() async {
+    func send_viewAppeared_refreshes_sources_when_custom_metrics_configuration_change_is_emitted() async {
         let appState = AllocatedUnfairLock<AppState>(initialState: .init())
         let storage = UserDefaultsClient.storage()
         let sut = MetricsBarSettings(.testDependencies(
             appStateClient: .testDependency(appState),
             userDefaultsClient: storage.client
         ))
-        await sut.send(.task("MetricsBarSettingsTests"))
+        await sut.send(.viewAppeared("MetricsBarSettingsTests"))
         #expect(sut.customMetricsSources.isEmpty)
         let source = makeSource(id: UUID(1))
         let encodedConfiguration = try? JSONEncoder().encode(CustomMetricsConfiguration(sources: [source]))
@@ -48,7 +48,7 @@ struct MetricsBarSettingsTests {
         appState.withLock { $0.customMetricsConfigurationChanges.send() }
         await waitUntil { sut.customMetricsSources == [source] }
         #expect(sut.customMetricsSources == [source])
-        await sut.send(.onDisappear)
+        await sut.send(.viewDisappeared)
     }
 
     @MainActor @Test

--- a/LocalPackage/Tests/ModelTests/StoreTests/MetricsBarTests.swift
+++ b/LocalPackage/Tests/ModelTests/StoreTests/MetricsBarTests.swift
@@ -19,20 +19,20 @@ struct MetricsBarTests {
     }
 
     @MainActor @Test
-    func send_task_loads_latest_metrics_and_observes_stream() async {
+    func send_viewAppeared_loads_latest_metrics_and_observes_stream() async {
         let appState = AllocatedUnfairLock<AppState>(initialState: .init())
         appState.withLock { $0.metrics.send(Metrics.dummy(cpuRawValue: 0.1)) }
         let sut = MetricsBar(.testDependencies(appStateClient: .testDependency(appState)))
-        await sut.send(.task("MetricsBarTests"))
+        await sut.send(.viewAppeared("MetricsBarTests"))
         #expect(sut.systemInfoBundle.cpuInfo?.percentage.value == 10.0)
         appState.withLock { $0.metrics.send(Metrics.dummy(cpuRawValue: 0.2)) }
         await waitUntil { sut.systemInfoBundle.cpuInfo?.percentage.value == 20.0 }
         #expect(sut.systemInfoBundle.cpuInfo?.percentage.value == 20.0)
-        await sut.send(.onDisappear)
+        await sut.send(.viewDisappeared)
     }
 
     @MainActor @Test
-    func send_task_refreshes_configuration_when_change_event_is_emitted() async throws {
+    func send_viewAppeared_refreshes_configuration_when_change_event_is_emitted() async throws {
         let appState = AllocatedUnfairLock<AppState>(initialState: .init())
         let configurationData = AllocatedUnfairLock<Data?>(initialState: nil)
         let sut = MetricsBar(.testDependencies(
@@ -41,7 +41,7 @@ struct MetricsBarTests {
                 $0.data = { _ in configurationData.withLock(\.self) }
             }
         ))
-        await sut.send(.task("MetricsBarTests"))
+        await sut.send(.viewAppeared("MetricsBarTests"))
         #expect(sut.metricsBarConfiguration == .default)
         let updatedConfiguration = MetricsBarConfiguration(
             showsCPU: true,
@@ -56,11 +56,11 @@ struct MetricsBarTests {
         appState.withLock { $0.systemMetricsConfigurationChanges.send() }
         await waitUntil { sut.metricsBarConfiguration == updatedConfiguration }
         #expect(sut.metricsBarConfiguration == updatedConfiguration)
-        await sut.send(.onDisappear)
+        await sut.send(.viewDisappeared)
     }
 
     @MainActor @Test
-    func send_task_refreshes_visibility_when_custom_metrics_configuration_change_is_emitted() async {
+    func send_viewAppeared_refreshes_visibility_when_custom_metrics_configuration_change_is_emitted() async {
         let appState = AllocatedUnfairLock<AppState>(initialState: .init())
         var initialMetricsBarConfiguration = MetricsBarConfiguration.default
         initialMetricsBarConfiguration.visibleCustomMetricsSourceIDs = [UUID(1)]
@@ -72,22 +72,22 @@ struct MetricsBarTests {
             appStateClient: .testDependency(appState),
             userDefaultsClient: storage.client
         ))
-        await sut.send(.task("MetricsBarTests"))
+        await sut.send(.viewAppeared("MetricsBarTests"))
         #expect(sut.metricsBarConfiguration.visibleCustomMetricsSourceIDs == [UUID(1)])
         let service = CustomMetricsService(.testDependencies(userDefaultsClient: storage.client))
         service.removeSource(of: UUID(1))
         appState.withLock { $0.customMetricsConfigurationChanges.send() }
         await waitUntil { sut.metricsBarConfiguration.visibleCustomMetricsSourceIDs.isEmpty }
         #expect(sut.metricsBarConfiguration.visibleCustomMetricsSourceIDs.isEmpty)
-        await sut.send(.onDisappear)
+        await sut.send(.viewDisappeared)
     }
 
     @MainActor @Test
-    func send_onDisappear_stops_observing_streams() async {
+    func send_viewDisappeared_stops_observing_streams() async {
         let appState = AllocatedUnfairLock<AppState>(initialState: .init())
         let sut = MetricsBar(.testDependencies(appStateClient: .testDependency(appState)))
-        await sut.send(.task("MetricsBarTests"))
-        await sut.send(.onDisappear)
+        await sut.send(.viewAppeared("MetricsBarTests"))
+        await sut.send(.viewDisappeared)
         appState.withLock { $0.metrics.send(Metrics.dummy(cpuRawValue: 0.3)) }
         try? await Task.sleep(for: .milliseconds(50))
         #expect(sut.systemInfoBundle.cpuInfo == nil)

--- a/LocalPackage/Tests/ModelTests/StoreTests/MetricsSettingsTests.swift
+++ b/LocalPackage/Tests/ModelTests/StoreTests/MetricsSettingsTests.swift
@@ -8,14 +8,14 @@ import Testing
 
 struct MetricsSettingsTests {
     @MainActor @Test
-    func send_task_refreshes_configuration_when_change_event_is_emitted() async throws {
+    func send_viewAppeared_refreshes_configuration_when_change_event_is_emitted() async throws {
         let appState = AllocatedUnfairLock<AppState>(initialState: .init())
         let storage = UserDefaultsClient.storage()
         let sut = MetricsSettings(.testDependencies(
             appStateClient: .testDependency(appState),
             userDefaultsClient: storage.client
         ))
-        await sut.send(.task("MetricsSettingsTests"))
+        await sut.send(.viewAppeared("MetricsSettingsTests"))
         #expect(sut.systemMetricsConfiguration == .default)
         let updatedConfiguration = SystemMetricsConfiguration(
             monitorsMemory: false,
@@ -28,19 +28,19 @@ struct MetricsSettingsTests {
         appState.withLock { $0.systemMetricsConfigurationChanges.send() }
         await waitUntil { sut.systemMetricsConfiguration == updatedConfiguration }
         #expect(sut.systemMetricsConfiguration == updatedConfiguration)
-        await sut.send(.onDisappear)
+        await sut.send(.viewDisappeared)
     }
 
     @MainActor @Test
-    func send_onDisappear_stops_observing_configuration_changes() async throws {
+    func send_viewDisappeared_stops_observing_configuration_changes() async throws {
         let appState = AllocatedUnfairLock<AppState>(initialState: .init())
         let storage = UserDefaultsClient.storage()
         let sut = MetricsSettings(.testDependencies(
             appStateClient: .testDependency(appState),
             userDefaultsClient: storage.client
         ))
-        await sut.send(.task("MetricsSettingsTests"))
-        await sut.send(.onDisappear)
+        await sut.send(.viewAppeared("MetricsSettingsTests"))
+        await sut.send(.viewDisappeared)
         let updatedConfiguration = SystemMetricsConfiguration(
             monitorsMemory: false,
             monitorsStorage: false,
@@ -179,9 +179,9 @@ struct MetricsSettingsTests {
     }
 
     @MainActor @Test
-    func send_customMetricsSettings_onError_shows_alert() async {
+    func send_customMetricsSettings_errorOccurred_shows_alert() async {
         let sut = MetricsSettings(.testDependencies())
-        await sut.send(.customMetricsSettings(.onError(.customMetrics(.fileUnreadable))))
+        await sut.send(.customMetricsSettings(.errorOccurred(.customMetrics(.fileUnreadable))))
         #expect(sut.error == .customMetrics(.fileUnreadable))
         #expect(sut.showingAlert == true)
     }

--- a/LocalPackage/Tests/ModelTests/StoreTests/RunnerBarTests.swift
+++ b/LocalPackage/Tests/ModelTests/StoreTests/RunnerBarTests.swift
@@ -27,7 +27,7 @@ struct RunnerBarTests {
     }
 
     @MainActor @Test
-    func send_task_applies_latest_runner_bundle_to_event_bridge() async {
+    func send_viewAppeared_applies_latest_runner_bundle_to_event_bridge() async {
         let appState = AllocatedUnfairLock<AppState>(initialState: .init())
         appState.withLock {
             $0.runnerBundles.send(RunnerBundle(
@@ -37,7 +37,7 @@ struct RunnerBarTests {
         }
         let callStack = AllocatedUnfairLock<[String]>(initialState: [])
         let sut = RunnerBar(.testDependencies(appStateClient: .testDependency(appState)))
-        await sut.send(.task("RunnerBarTests", makeEventBridge(recording: callStack)))
+        await sut.send(.viewAppeared("RunnerBarTests", makeEventBridge(recording: callStack)))
         await waitUntil { callStack.withLock(\.self).count >= 4 }
         #expect(sut.isReady == true)
         #expect(sut.size == CGSize(width: 10, height: 18))
@@ -48,45 +48,45 @@ struct RunnerBarTests {
             "setSize: 10.0x18.0",
             "setFrames: 2, true",
         ])
-        await sut.send(.onDisappear)
+        await sut.send(.viewDisappeared)
     }
 
     @MainActor @Test
-    func send_task_applies_runner_speed_to_event_bridge() async {
+    func send_viewAppeared_applies_runner_speed_to_event_bridge() async {
         let appState = AllocatedUnfairLock<AppState>(initialState: .init())
         appState.withLock { $0.runnerSpeeds.send(12.5) }
         let callStack = AllocatedUnfairLock<[String]>(initialState: [])
         let sut = RunnerBar(.testDependencies(appStateClient: .testDependency(appState)))
-        await sut.send(.task("RunnerBarTests", makeEventBridge(recording: callStack)))
+        await sut.send(.viewAppeared("RunnerBarTests", makeEventBridge(recording: callStack)))
         await waitUntil { !callStack.withLock(\.self).isEmpty }
         #expect(callStack.withLock(\.self) == ["setSpeed: 12.5"])
-        await sut.send(.onDisappear)
+        await sut.send(.viewDisappeared)
     }
 
     @MainActor @Test
-    func send_task_ignores_thumbnail_bundle() async {
+    func send_viewAppeared_ignores_thumbnail_bundle() async {
         let appState = AllocatedUnfairLock<AppState>(initialState: .init())
         appState.withLock {
             $0.runnerBundles.send(RunnerBundle(runner: .default, frame: .preset("cat-frame-0")))
         }
         let callStack = AllocatedUnfairLock<[String]>(initialState: [])
         let sut = RunnerBar(.testDependencies(appStateClient: .testDependency(appState)))
-        await sut.send(.task("RunnerBarTests", makeEventBridge(recording: callStack)))
+        await sut.send(.viewAppeared("RunnerBarTests", makeEventBridge(recording: callStack)))
         try? await Task.sleep(for: .milliseconds(50))
         #expect(callStack.withLock(\.self).isEmpty)
         #expect(sut.icon == nil)
-        await sut.send(.onDisappear)
+        await sut.send(.viewDisappeared)
     }
 
     @MainActor @Test
-    func send_task_with_broken_frames_clears_icon() async {
+    func send_viewAppeared_with_broken_frames_clears_icon() async {
         let appState = AllocatedUnfairLock<AppState>(initialState: .init())
         appState.withLock {
             $0.runnerBundles.send(RunnerBundle(runner: .default, frames: [.broken]))
         }
         let callStack = AllocatedUnfairLock<[String]>(initialState: [])
         let sut = RunnerBar(.testDependencies(appStateClient: .testDependency(appState)))
-        await sut.send(.task("RunnerBarTests", makeEventBridge(recording: callStack)))
+        await sut.send(.viewAppeared("RunnerBarTests", makeEventBridge(recording: callStack)))
         await waitUntil { callStack.withLock(\.self).count >= 2 }
         #expect(sut.icon == nil)
         #expect(sut.size == .zero)
@@ -94,16 +94,16 @@ struct RunnerBarTests {
             "setSize: 0.0x0.0",
             "setFrames: 0, true",
         ])
-        await sut.send(.onDisappear)
+        await sut.send(.viewDisappeared)
     }
 
     @MainActor @Test
-    func send_onDisappear_stops_observing_streams() async {
+    func send_viewDisappeared_stops_observing_streams() async {
         let appState = AllocatedUnfairLock<AppState>(initialState: .init())
         let callStack = AllocatedUnfairLock<[String]>(initialState: [])
         let sut = RunnerBar(.testDependencies(appStateClient: .testDependency(appState)))
-        await sut.send(.task("RunnerBarTests", makeEventBridge(recording: callStack)))
-        await sut.send(.onDisappear)
+        await sut.send(.viewAppeared("RunnerBarTests", makeEventBridge(recording: callStack)))
+        await sut.send(.viewDisappeared)
         appState.withLock { $0.runnerSpeeds.send(5.0) }
         try? await Task.sleep(for: .milliseconds(50))
         #expect(callStack.withLock(\.self).isEmpty)

--- a/LocalPackage/Tests/ModelTests/StoreTests/RunnerSettingsTests.swift
+++ b/LocalPackage/Tests/ModelTests/StoreTests/RunnerSettingsTests.swift
@@ -48,9 +48,9 @@ struct RunnerSettingsTests {
     }
 
     @MainActor @Test
-    func send_customRunnerSettings_onError_shows_alert() async {
+    func send_customRunnerSettings_errorOccurred_shows_alert() async {
         let sut = RunnerSettings(.testDependencies())
-        await sut.send(.customRunnerSettings(.onError(.customRunner(.loadingFailed))))
+        await sut.send(.customRunnerSettings(.errorOccurred(.customRunner(.loadingFailed))))
         #expect(sut.error == .customRunner(.loadingFailed))
         #expect(sut.showingAlert == true)
     }


### PR DESCRIPTION
## Context of Contribution

- [x] Refactoring

> **Stacked on #78** — base branch is `feat/runner-picker-in-menu`. Merge that one first; this PR will retarget to `main` automatically.

## Summary of the Proposal

Store `Action` cases carried two conventions at once. Most already read subject-first and past-tense (`settingsButtonTapped`, `slowDownUnderLoadToggleSwitched`), but every case wired to a SwiftUI modifier borrowed that modifier's name instead — `task`, `onDisappear`, `onDropFiles`, `onCompletionFileImporter`, `onTapCollectionBackground`. The enum then told you *which modifier fired* rather than *what happened*, and the pickers had a third shape again (`updateIntervalChanged`, `selectRenderingMode`).

This settles on subject-first past tense everywhere:

| Before | After |
| --- | --- |
| `task(String)` | `viewAppeared(String)` |
| `onDisappear` | `viewDisappeared` |
| `onError(RCNError)` | `errorOccurred(RCNError)` |
| `onDissmissSheet` | `sheetDismissed` |
| `onTapFrameImageCell(FrameImage)` | `frameImageCellTapped(FrameImage)` |
| `onTapCollectionBackground` | `collectionBackgroundTapped` |
| `onDropFiles([URL])` | `filesDropped([URL])` |
| `onMoveCustomRunnerRow(IndexSet, Int)` | `customRunnerRowMoved(IndexSet, Int)` |
| `onMoveCustomMetricsSourceRow(IndexSet, Int)` | `customMetricsSourceRowMoved(IndexSet, Int)` |
| `onCompletionFileImporter(Result<[URL], any Error>)` | `fileImporterResponse(Result<[URL], any Error>)` |
| `onPurchaseCompleted(Product, Result<…>)` | `purchaseResponse(Product, Result<…>)` |
| `onReceiveProductTaskState(…)` | `productTaskStateChanged(…)` |
| `onReceiveSubscriptionTaskState(…)` | `subscriptionTaskStateChanged(…)` |
| `updateIntervalChanged(UpdateInterval)` | `updateIntervalPickerSelected(UpdateInterval)` |
| `selectRenderingMode(RenderingMode)` | `renderingModePickerSelected(RenderingMode)` |

The SwiftUI modifiers keep their names — `.task {}` and `.onDisappear {}` are unchanged; only the Actions they send are renamed. `CustomMetricsSettings` and `CustomRunnerSettings` are sections rather than screens and log no `screenView`, so their `viewAppeared` stays payload-free. The rename also drops the `Dissmiss` typo.

Test function names follow (`send_viewAppeared_…`), and `CODING_STYLE.md` is updated because its naming example cited one of the renamed tests.

This matches the [LUCA house style](https://github.com/Kyome22/LUCA-Skills), which is being updated in the same pass.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) and agree to follow it.
- [x] This PR does not contain commits of multiple contexts.
- [x] The diff is minimal — no unrelated refactors, whitespace churn, or drive-by cleanups.
- [x] Code follows proper indentation and naming conventions.
- [x] Layering follows the [LUCA architecture](../blob/main/ARCHITECTURE.md): no logic in `DependencyClient`, no logic in `UserInterface` views, no Asset/String Catalog references from `Model`.
- [x] Implemented using only APIs that can be submitted to the App Store.

## Verification

Pure rename — the diff is 214 insertions and 214 deletions across 33 files, with no behavioural change. Clean build with 0 errors and 0 warnings; 171/171 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)