### PR TITLE
Scope the test-run detail to the xcodebuild fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,9 @@ RunCat Neo is a macOS menu-bar app that animates a running cat in the status bar
 
 The app shell lives in `RunCatNeo.xcodeproj` and embeds the local Swift Package `LocalPackage/`, which contains essentially all source code. The `xcode` MCP tools (`mcp__xcode__BuildProject`, `mcp__xcode__RunAllTests`, etc.) are the preferred way to build and run tests — fall back to `xcodebuild` only when MCP is unavailable.
 
-Tests live only in the SPM package (`DataSourceTests`, `ModelTests`) and use Swift Testing (`@Test`, `#expect`). Run via the `LocalPackage-Package` scheme on `platform=macOS,arch=arm64`. There are no UI tests and no linter configured.
+Tests live only in the SPM package (`DataSourceTests`, `ModelTests`) and use Swift Testing (`@Test`, `#expect`). There are no UI tests and no linter configured.
+
+On the `xcodebuild` fallback only: run it from `LocalPackage/` with the `LocalPackage-Package` scheme on `platform=macOS,arch=arm64`. SwiftPM generates that scheme for the package, so it is not listed at the repository root — from there the equivalent is the `RunCatNeo` scheme and its `UnitTest.xctestplan`, which cover the same two targets. CI takes the former path (`working-directory: LocalPackage`).
 
 CI (`.github/workflows/test.yml`) runs on tag pushes only — local test runs are the primary verification loop during development.
 


### PR DESCRIPTION
## Context of Contribution

- [x] Others (documentation fix)

> **Correction.** An earlier revision of this PR claimed the `LocalPackage-Package` scheme did not exist and replaced it with the `RunCatNeo` scheme. That was wrong — the scheme does exist and is exactly what CI uses. A second revision kept it but wrote the `xcodebuild` mechanics into the main paragraph, which blurred the "MCP first" rule. This revision fixes both.

## Summary of the Proposal

CLAUDE.md already states the tool preference:

> The `xcode` MCP tools … are the preferred way to build and run tests — fall back to `xcodebuild` only when MCP is unavailable.

The scheme line sat below it as a bare *"Run via the `LocalPackage-Package` scheme on `platform=macOS,arch=arm64`"*, with no directory. SwiftPM generates that scheme for the package, so it is invisible from the repository root:

```
$ xcodebuild -list -project RunCatNeo.xcodeproj      $ cd LocalPackage && xcodebuild -list
    Schemes:                                             Schemes:
        DataSource                                           DataSource
        Model                                                LocalPackage-Package
        RunCatNeo                                            Model
        UserInterface                                        UserInterface
```

Running it from the root therefore fails with "scheme not found", which reads as the documentation being stale rather than as a missing `cd`.

This adds the directory but keeps it **in its own paragraph, explicitly marked fallback-only**, so the `xcodebuild` mechanics do not read as the primary path — the previous revision of this PR made exactly that mistake by putting them in the main sentence. It also notes the root-level equivalent (the `RunCatNeo` scheme and its `UnitTest.xctestplan`, covering the same two targets) and that CI uses `working-directory: LocalPackage`.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) and agree to follow it.
- [x] This PR does not contain commits of multiple contexts.
- [x] The diff is minimal — no unrelated refactors, whitespace churn, or drive-by cleanups.
- [x] Code follows proper indentation and naming conventions.
- [x] Layering follows the [LUCA architecture](../blob/main/ARCHITECTURE.md): no logic in `DependencyClient`, no logic in `UserInterface` views, no Asset/String Catalog references from `Model`.
- [x] Implemented using only APIs that can be submitted to the App Store.

## Verification

`xcodebuild -list` from both directories (above), `.github/workflows/test.yml` for the CI invocation, and `RunCatNeo.xcscheme` for the `UnitTest.xctestplan` reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)