### PR TITLE
Drop redundant boolean comparisons from test assertions

### DIFF
--- a/CODING_STYLE.md
+++ b/CODING_STYLE.md
@@ -67,6 +67,18 @@ These are the authoritative line-level style rules for all Swift code in this re
 - Name test functions in snake_case as `subject_condition_expectation` (e.g. `decode_throws_when_title_missing`, `send_viewAppeared_reloads_customMetricsSources_from_user_defaults`).
 - Compare whole `Equatable` values with a single `#expect` instead of asserting properties one by one; add `Equatable` conformance to entities when tests need it.
 - Pass the expression under test directly to `#expect` instead of binding it to a temporary constant like `actual`; bind a constant (with a meaningful name) only when multiple assertions need the same value.
+- Write boolean assertions as `#expect(value)` and `#expect(!value)` — never `#expect(value == true)` or `#expect(value == false)`.
+- When the asserted value is `Bool?`, unwrap the optional with `try #require` into a named constant first and assert on that, adding `throws` to the test function as needed.
+  This is the one case where binding a constant for a single assertion is expected.
+
+  ```swift
+  let removedContainerURL = try #require(removedURL.withLock { $0 })
+  #expect(removedContainerURL.hasPathSuffix("RunCatNeo/alpha"))
+  ```
+
+- Read an `AllocatedUnfairLock` inside `#require` with the closure form (`withLock { $0 }`), not the key-path form (`withLock(\.self)`), because the macro expansion loses the key path's root type and fails to compile.
+  The key-path form remains fine inside `#expect`.
+- `waitUntil { … }` takes a plain `() -> Bool`, so `== true` and `== false` stay there as the way to flatten an optional condition.
 - Use `AllocatedUnfairLock` for mutable state captured by mock dependency closures.
 
 ## License Headers

--- a/LocalPackage/Tests/DataSourceTests/RepositoryTests/ApplicationSupportRepositoryTests.swift
+++ b/LocalPackage/Tests/DataSourceTests/RepositoryTests/ApplicationSupportRepositoryTests.swift
@@ -63,7 +63,7 @@ struct ApplicationSupportRepositoryTests {
     }
 
     @Test
-    func loadCustomRunners_reads_runners_from_customRunners_file() {
+    func loadCustomRunners_reads_runners_from_customRunners_file() throws {
         let readURL = AllocatedUnfairLock<URL?>(initialState: nil)
         let json = """
             [
@@ -86,7 +86,8 @@ struct ApplicationSupportRepositoryTests {
         }
         let sut = ApplicationSupportRepository(dataClient, fileManagerClient)
         #expect(sut.loadCustomRunners() == [Runner(id: "custom", name: "Custom", isTemplate: false, frameOrder: .custom([0, 1]))])
-        #expect(readURL.withLock(\.self)?.hasPathSuffix("RunCatNeo/CUSTOM_RUNNERS.json") == true)
+        let readCustomRunnersURL = try #require(readURL.withLock { $0 })
+        #expect(readCustomRunnersURL.hasPathSuffix("RunCatNeo/CUSTOM_RUNNERS.json"))
     }
 
     @Test
@@ -185,7 +186,7 @@ struct ApplicationSupportRepositoryTests {
     }
 
     @Test
-    func loadData_returns_file_contents_when_file_exists() {
+    func loadData_returns_file_contents_when_file_exists() throws {
         let readURL = AllocatedUnfairLock<URL?>(initialState: nil)
         let dataClient = testDependency(of: DataClient.self) {
             $0.read = { url in
@@ -198,7 +199,8 @@ struct ApplicationSupportRepositoryTests {
         }
         let sut = ApplicationSupportRepository(dataClient, fileManagerClient)
         #expect(sut.loadData(directory: "alpha", fileName: "frame-0", fileType: .png) == Data("image".utf8))
-        #expect(readURL.withLock(\.self)?.hasPathSuffix("RunCatNeo/alpha/frame-0.png") == true)
+        let readFrameURL = try #require(readURL.withLock { $0 })
+        #expect(readFrameURL.hasPathSuffix("RunCatNeo/alpha/frame-0.png"))
     }
 
     @Test
@@ -218,8 +220,10 @@ struct ApplicationSupportRepositoryTests {
         }
         let sut = ApplicationSupportRepository(dataClient, fileManagerClient)
         try sut.saveData(directory: "alpha", fileName: "frame-0", fileType: .png, data: Data())
-        #expect(createdDirectoryURL.withLock(\.self)?.hasPathSuffix("RunCatNeo/alpha") == true)
-        #expect(writtenURL.withLock(\.self)?.hasPathSuffix("RunCatNeo/alpha/frame-0.png") == true)
+        let createdContainerURL = try #require(createdDirectoryURL.withLock { $0 })
+        #expect(createdContainerURL.hasPathSuffix("RunCatNeo/alpha"))
+        let writtenFrameURL = try #require(writtenURL.withLock { $0 })
+        #expect(writtenFrameURL.hasPathSuffix("RunCatNeo/alpha/frame-0.png"))
     }
 
     @Test
@@ -251,7 +255,7 @@ struct ApplicationSupportRepositoryTests {
     }
 
     @Test
-    func delete_removes_container_directory_when_it_exists() {
+    func delete_removes_container_directory_when_it_exists() throws {
         let removedURL = AllocatedUnfairLock<URL?>(initialState: nil)
         let fileManagerClient = testDependency(of: FileManagerClient.self) {
             $0.fileExists = { _ in true }
@@ -261,7 +265,8 @@ struct ApplicationSupportRepositoryTests {
         }
         let sut = ApplicationSupportRepository(.testValue, fileManagerClient)
         sut.delete(directory: "alpha")
-        #expect(removedURL.withLock(\.self)?.hasPathSuffix("RunCatNeo/alpha") == true)
+        let removedContainerURL = try #require(removedURL.withLock { $0 })
+        #expect(removedContainerURL.hasPathSuffix("RunCatNeo/alpha"))
     }
 
     @Test

--- a/LocalPackage/Tests/ModelTests/ServiceTests/CustomMetricsServiceTests.swift
+++ b/LocalPackage/Tests/ModelTests/ServiceTests/CustomMetricsServiceTests.swift
@@ -213,7 +213,8 @@ struct CustomMetricsServiceTests {
         sut.stopMonitoring()
         #expect(appState.withLock(\.customMetricsReconcileObserver) == nil)
         #expect(appState.withLock(\.customMetricsObservers).isEmpty)
-        #expect(appState.withLock(\.metrics.latestValue)?.customMetricsBundles.isEmpty == true)
+        let metrics = try #require(appState.withLock { $0.metrics.latestValue })
+        #expect(metrics.customMetricsBundles.isEmpty)
         #expect(reconcileObserver.isCancelled)
         #expect(sourceObserver.isCancelled)
     }
@@ -266,7 +267,8 @@ struct CustomMetricsServiceTests {
         sut.emitConfigurationChange()
         await waitUntil { appState.withLock(\.customMetricsObservers).isEmpty }
         #expect(appState.withLock(\.customMetricsObservers).isEmpty)
-        #expect(appState.withLock(\.metrics.latestValue)?.customMetricsBundles.isEmpty == true)
+        let metrics = try #require(appState.withLock { $0.metrics.latestValue })
+        #expect(metrics.customMetricsBundles.isEmpty)
         sut.stopMonitoring()
     }
 
@@ -292,7 +294,8 @@ struct CustomMetricsServiceTests {
         ))
         sut.startMonitoring()
         await waitUntil { appState.withLock(\.metrics.latestValue)?.customMetricsBundles.first?.isFailed == true }
-        #expect(appState.withLock(\.metrics.latestValue)?.customMetricsBundles.first?.isFailed == true)
+        let failedBundle = try #require(appState.withLock { $0.metrics.latestValue }?.customMetricsBundles.first)
+        #expect(failedBundle.isFailed)
         sut.stopMonitoring()
     }
 

--- a/LocalPackage/Tests/ModelTests/ServiceTests/RunnerServiceTests.swift
+++ b/LocalPackage/Tests/ModelTests/ServiceTests/RunnerServiceTests.swift
@@ -312,13 +312,13 @@ struct RunnerServiceTests {
                 $0.fileExists = { _ in true }
             }
         ))
-        #expect(sut.validate(customRunnerName: "Custom Runner") == false)
+        #expect(!sut.validate(customRunnerName: "Custom Runner"))
     }
 
     @Test
     func validate_returns_true_when_custom_runner_name_is_not_used() {
         let sut = RunnerService(.testDependencies())
-        #expect(sut.validate(customRunnerName: "Custom Runner") == true)
+        #expect(sut.validate(customRunnerName: "Custom Runner"))
     }
 
     @Test
@@ -405,7 +405,8 @@ struct RunnerServiceTests {
         try sut.delete(customRunner: Runner(id: "custom-runner", name: "Custom Runner", isTemplate: false, frameOrder: .custom([0])))
         let expectedJSON = #"[{"frameOrder":[0],"id":"other-runner","isTemplate":false,"name":"Other Runner"}]"#
         #expect(writtenJSON.withLock(\.self) == expectedJSON)
-        #expect(removedURL.withLock(\.self)?.hasPathSuffix("RunCatNeo/custom-runner") == true)
+        let removedDirectoryURL = try #require(removedURL.withLock { $0 })
+        #expect(removedDirectoryURL.hasPathSuffix("RunCatNeo/custom-runner"))
     }
 
     @Test

--- a/LocalPackage/Tests/ModelTests/StoreTests/CustomMetricsSettingsTests.swift
+++ b/LocalPackage/Tests/ModelTests/StoreTests/CustomMetricsSettingsTests.swift
@@ -72,7 +72,7 @@ struct CustomMetricsSettingsTests {
         await sut.send(.viewAppeared)
         await sut.send(.removeCustomMetricsSourceButtonTapped(existingID))
         #expect(sut.pendingRemovalSourceID == existingID)
-        #expect(sut.showingConfirmationDialog == true)
+        #expect(sut.showingConfirmationDialog)
         #expect(sut.customMetricsSources.count == 1)
     }
 
@@ -209,14 +209,14 @@ struct CustomMetricsSettingsTests {
     func send_addCustomMetricsSourceButtonTapped_shows_file_importer() async {
         let sut = CustomMetricsSettings(.testDependencies())
         await sut.send(.addCustomMetricsSourceButtonTapped)
-        #expect(sut.showingFileImporter == true)
+        #expect(sut.showingFileImporter)
     }
 
     @MainActor @Test
     func send_infoButtonTapped_shows_info_popover() async {
         let sut = CustomMetricsSettings(.testDependencies())
         await sut.send(.infoButtonTapped)
-        #expect(sut.showingInfoPopover == true)
+        #expect(sut.showingInfoPopover)
     }
 
     @MainActor @Test

--- a/LocalPackage/Tests/ModelTests/StoreTests/CustomRunnerSettingsTests.swift
+++ b/LocalPackage/Tests/ModelTests/StoreTests/CustomRunnerSettingsTests.swift
@@ -132,7 +132,7 @@ struct CustomRunnerSettingsTests {
     func send_addCustomRunnerButtonTapped_shows_editor_sheet() async {
         let sut = CustomRunnerSettings(.testDependencies())
         await sut.send(.addCustomRunnerButtonTapped)
-        #expect(sut.showingCustomRunnerEditorSheet == true)
+        #expect(sut.showingCustomRunnerEditorSheet)
     }
 
     @MainActor @Test
@@ -142,7 +142,7 @@ struct CustomRunnerSettingsTests {
             showingCustomRunnerEditorSheet: true
         )
         await sut.send(.cancelButtonTapped)
-        #expect(sut.showingCustomRunnerEditorSheet == false)
+        #expect(!sut.showingCustomRunnerEditorSheet)
     }
 
     @MainActor @Test
@@ -159,7 +159,7 @@ struct CustomRunnerSettingsTests {
         )
         await sut.send(.sheetDismissed)
         #expect(sut.runnerName.isEmpty)
-        #expect(sut.isTemplate == true)
+        #expect(sut.isTemplate)
         #expect(sut.frameImages.isEmpty)
         #expect(sut.selectingFrameImage == nil)
         #expect(sut.previewingFrameImage == nil)
@@ -170,9 +170,9 @@ struct CustomRunnerSettingsTests {
     func send_renderingModePickerSelected_updates_isTemplate() async {
         let sut = CustomRunnerSettings(.testDependencies())
         await sut.send(.renderingModePickerSelected(.color))
-        #expect(sut.isTemplate == false)
+        #expect(!sut.isTemplate)
         await sut.send(.renderingModePickerSelected(.monochrome))
-        #expect(sut.isTemplate == true)
+        #expect(sut.isTemplate)
     }
 
     @MainActor @Test
@@ -210,7 +210,7 @@ struct CustomRunnerSettingsTests {
     func send_addFrameButtonTapped_shows_file_importer() async {
         let sut = CustomRunnerSettings(.testDependencies())
         await sut.send(.addFrameButtonTapped)
-        #expect(sut.showingFileImporter == true)
+        #expect(sut.showingFileImporter)
     }
 
     @MainActor @Test
@@ -358,6 +358,6 @@ struct CustomRunnerSettingsTests {
     func send_infoButtonTapped_shows_info_popover() async {
         let sut = CustomRunnerSettings(.testDependencies())
         await sut.send(.infoButtonTapped)
-        #expect(sut.showingInfoPopover == true)
+        #expect(sut.showingInfoPopover)
     }
 }

--- a/LocalPackage/Tests/ModelTests/StoreTests/GeneralSettingsTests.swift
+++ b/LocalPackage/Tests/ModelTests/StoreTests/GeneralSettingsTests.swift
@@ -43,7 +43,7 @@ struct GeneralSettingsTests {
             }
         ))
         await sut.send(.launchAtLoginToggleSwitched(true))
-        #expect(sut.launchesAtLogin == true)
+        #expect(sut.launchesAtLogin)
     }
 
     @MainActor @Test
@@ -55,6 +55,6 @@ struct GeneralSettingsTests {
             }
         ))
         await sut.send(.launchAtLoginToggleSwitched(true))
-        #expect(sut.launchesAtLogin == false)
+        #expect(!sut.launchesAtLogin)
     }
 }

--- a/LocalPackage/Tests/ModelTests/StoreTests/MetricsBarSettingsTests.swift
+++ b/LocalPackage/Tests/ModelTests/StoreTests/MetricsBarSettingsTests.swift
@@ -83,13 +83,14 @@ struct MetricsBarSettingsTests {
             userDefaultsClient: storage.client
         ))
         await sut.send(.showsSystemMetricsToggleSwitched(.memory, true))
-        #expect(sut.metricsBarConfiguration.showsMemory == true)
-        #expect(storage.currentMetricsBarConfiguration()?.showsMemory == true)
+        #expect(sut.metricsBarConfiguration.showsMemory)
+        let storedBarConfiguration = try #require(storage.currentMetricsBarConfiguration())
+        #expect(storedBarConfiguration.showsMemory)
         let storedConfiguration = try JSONDecoder().decode(
             SystemMetricsConfiguration.self,
             from: try #require(storage.lock.withLock { $0[.systemMetricsConfiguration] })
         )
-        #expect(storedConfiguration.monitorsMemory == true)
+        #expect(storedConfiguration.monitorsMemory)
         #expect(activationRequests.withLock(\.self) == [.memory: true])
         #expect(appState.withLock(\.systemMetricsConfigurationChanges.latestValue) != nil)
     }
@@ -105,12 +106,12 @@ struct MetricsBarSettingsTests {
             userDefaultsClient: storage.client
         ))
         await sut.send(.showsSystemMetricsToggleSwitched(.cpu, true))
-        #expect(sut.metricsBarConfiguration.showsCPU == true)
+        #expect(sut.metricsBarConfiguration.showsCPU)
         #expect(activationCount.withLock(\.self) == 0)
     }
 
     @MainActor @Test
-    func send_showsCustomMetricsToggleSwitched_persists_visibility_and_emits_change() async {
+    func send_showsCustomMetricsToggleSwitched_persists_visibility_and_emits_change() async throws {
         let appState = AllocatedUnfairLock<AppState>(initialState: .init())
         let storage = UserDefaultsClient.storage(initialSources: [makeSource(id: UUID(1))])
         let sut = MetricsBarSettings(.testDependencies(
@@ -123,6 +124,7 @@ struct MetricsBarSettingsTests {
         #expect(appState.withLock(\.systemMetricsConfigurationChanges.latestValue) != nil)
         await sut.send(.showsCustomMetricsToggleSwitched(UUID(1), false))
         #expect(sut.metricsBarConfiguration.visibleCustomMetricsSourceIDs.isEmpty)
-        #expect(storage.currentMetricsBarConfiguration()?.visibleCustomMetricsSourceIDs.isEmpty == true)
+        let storedBarConfiguration = try #require(storage.currentMetricsBarConfiguration())
+        #expect(storedBarConfiguration.visibleCustomMetricsSourceIDs.isEmpty)
     }
 }

--- a/LocalPackage/Tests/ModelTests/StoreTests/MetricsSettingsTests.swift
+++ b/LocalPackage/Tests/ModelTests/StoreTests/MetricsSettingsTests.swift
@@ -66,8 +66,8 @@ struct MetricsSettingsTests {
             }
         ))
         await sut.send(.showMetricsBarToggleSwitched(true))
-        #expect(sut.showingMetricsBarNotesSheet == true)
-        #expect(sut.showsMetricsBar == false)
+        #expect(sut.showingMetricsBarNotesSheet)
+        #expect(!sut.showsMetricsBar)
         #expect(setCallStack.withLock(\.self).isEmpty)
     }
 
@@ -83,8 +83,8 @@ struct MetricsSettingsTests {
             }
         ), showsMetricsBar: true)
         await sut.send(.showMetricsBarToggleSwitched(false))
-        #expect(sut.showingMetricsBarNotesSheet == false)
-        #expect(sut.showsMetricsBar == false)
+        #expect(!sut.showingMetricsBarNotesSheet)
+        #expect(!sut.showsMetricsBar)
         #expect(setCallStack.withLock(\.self) == ["set: SHOWS_METRICS_BAR = false"])
     }
 
@@ -100,8 +100,8 @@ struct MetricsSettingsTests {
             }
         ), showingMetricsBarNotesSheet: true)
         await sut.send(.changedMyMindButtonTapped)
-        #expect(sut.showingMetricsBarNotesSheet == false)
-        #expect(sut.showsMetricsBar == false)
+        #expect(!sut.showingMetricsBarNotesSheet)
+        #expect(!sut.showsMetricsBar)
         #expect(setCallStack.withLock(\.self).isEmpty)
     }
 
@@ -117,8 +117,8 @@ struct MetricsSettingsTests {
             }
         ), showingMetricsBarNotesSheet: true)
         await sut.send(.showButtonTapped)
-        #expect(sut.showingMetricsBarNotesSheet == false)
-        #expect(sut.showsMetricsBar == true)
+        #expect(!sut.showingMetricsBarNotesSheet)
+        #expect(sut.showsMetricsBar)
         #expect(setCallStack.withLock(\.self) == ["set: SHOWS_METRICS_BAR = true"])
     }
 
@@ -147,19 +147,19 @@ struct MetricsSettingsTests {
             userDefaultsClient: storage.client
         ))
         await sut.send(.monitorsSystemMetricsToggleSwitched(.memory, false))
-        #expect(sut.systemMetricsConfiguration.monitorsMemory == false)
+        #expect(!sut.systemMetricsConfiguration.monitorsMemory)
         let storedConfigurationData = storage.lock.withLock { $0[.systemMetricsConfiguration] }
         let storedConfiguration = try JSONDecoder().decode(
             SystemMetricsConfiguration.self,
             from: try #require(storedConfigurationData)
         )
-        #expect(storedConfiguration.monitorsMemory == false)
+        #expect(!storedConfiguration.monitorsMemory)
         let storedBarConfigurationData = storage.lock.withLock { $0[.metricsBarConfiguration] }
         let storedBarConfiguration = try JSONDecoder().decode(
             MetricsBarConfiguration.self,
             from: try #require(storedBarConfigurationData)
         )
-        #expect(storedBarConfiguration.showsMemory == false)
+        #expect(!storedBarConfiguration.showsMemory)
         #expect(activationRequests.withLock(\.self) == [.memory: false])
         #expect(appState.withLock(\.systemMetricsConfigurationChanges.latestValue) != nil)
     }
@@ -183,6 +183,6 @@ struct MetricsSettingsTests {
         let sut = MetricsSettings(.testDependencies())
         await sut.send(.customMetricsSettings(.errorOccurred(.customMetrics(.fileUnreadable))))
         #expect(sut.error == .customMetrics(.fileUnreadable))
-        #expect(sut.showingAlert == true)
+        #expect(sut.showingAlert)
     }
 }

--- a/LocalPackage/Tests/ModelTests/StoreTests/RunnerBarTests.swift
+++ b/LocalPackage/Tests/ModelTests/StoreTests/RunnerBarTests.swift
@@ -39,9 +39,9 @@ struct RunnerBarTests {
         let sut = RunnerBar(.testDependencies(appStateClient: .testDependency(appState)))
         await sut.send(.viewAppeared("RunnerBarTests", makeEventBridge(recording: callStack)))
         await waitUntil { callStack.withLock(\.self).count >= 4 }
-        #expect(sut.isReady == true)
+        #expect(sut.isReady)
         #expect(sut.size == CGSize(width: 10, height: 18))
-        #expect(sut.isTemplate == true)
+        #expect(sut.isTemplate)
         #expect(callStack.withLock(\.self) == [
             "getBundleImage: cat-frame-0",
             "getBundleImage: cat-frame-1",

--- a/LocalPackage/Tests/ModelTests/StoreTests/RunnerSettingsTests.swift
+++ b/LocalPackage/Tests/ModelTests/StoreTests/RunnerSettingsTests.swift
@@ -26,7 +26,7 @@ struct RunnerSettingsTests {
             userDefaultsClient: recorder.client
         ))
         await sut.send(.slowDownUnderLoadToggleSwitched(true))
-        #expect(sut.speedDecreasesUnderLoad == true)
+        #expect(sut.speedDecreasesUnderLoad)
         #expect(recorder.lock.withLock(\.self) == ["set: SPEED_DECREASES_UNDER_LOAD = true"])
         #expect(appState.withLock(\.runnerSpeeds.latestValue) == 1.0)
     }
@@ -42,7 +42,7 @@ struct RunnerSettingsTests {
             userDefaultsClient: recorder.client
         ))
         await sut.send(.flipHorizontallyToggleSwitched(true))
-        #expect(sut.isFlippedHorizontally == true)
+        #expect(sut.isFlippedHorizontally)
         #expect(recorder.lock.withLock(\.self) == ["set: IS_FLIPPED_HORIZONTALLY = true"])
         #expect(appState.withLock(\.runnerBundles.latestValue) == bundle)
     }
@@ -52,6 +52,6 @@ struct RunnerSettingsTests {
         let sut = RunnerSettings(.testDependencies())
         await sut.send(.customRunnerSettings(.errorOccurred(.customRunner(.loadingFailed))))
         #expect(sut.error == .customRunner(.loadingFailed))
-        #expect(sut.showingAlert == true)
+        #expect(sut.showingAlert)
     }
 }


### PR DESCRIPTION
## Context of Contribution

<!-- Each pull request should fix only one issue or propose one feature. -->
<!-- Do not mix unrelated changes in a single PR. -->

- [ ] Bug Fix
- [x] Refactoring
- [ ] New Feature
- [ ] Localization (new language or translation update)
- [ ] Others

## Summary of the Proposal

Every `#expect` asserting a boolean spelled it as a comparison — `x == true`, `x == false` — even though `#expect` takes a `Bool` expression directly.
The negative form was the worse half: `#expect(!x)` appeared nowhere in the suite, so "expect this to be false" was always written the long way.

All 45 sites now read `#expect(x)` or `#expect(!x)`.

Eleven of them had a `Bool?` on the left, where `== true` was quietly doing the nil-means-failure work.
Those unwrap with `try #require` into a named constant and assert on that, which is the idiom the files already used for decoding stored data:

```swift
// Before
#expect(removedURL.withLock(\.self)?.hasPathSuffix("RunCatNeo/alpha") == true)

// After
let removedContainerURL = try #require(removedURL.withLock { $0 })
#expect(removedContainerURL.hasPathSuffix("RunCatNeo/alpha"))
```

Four test functions gain `throws` to allow it.

One detail worth flagging for review: inside `#require`, the lock reads had to switch from `withLock(\.self)` to `withLock { $0 }`.
The macro rewrites its argument expression and the key path loses the context it needs to infer a root type, so the key-path form does not compile there.
`#expect` is unaffected and keeps it.

The four `== true` / `== false` inside `waitUntil` are left alone.
It takes a plain `() -> Bool`, so flattening the optional condition is the point rather than an oversight.

The second commit records the rule in `CODING_STYLE.md`, including the `waitUntil` exception so the remaining `== false` reads as deliberate.

Verified with `xcodebuild test` on the `LocalPackage-Package` scheme: 143 tests across 15 suites, all passing.
Test-only change — no production code touched.

## Reason for the new feature

<!-- If it's a new feature, explain why this feature is necessary. -->

N/A — refactoring.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) and agree to follow it.
- [x] This PR does not contain commits of multiple contexts.
- [x] The diff is minimal — no unrelated refactors, whitespace churn, or drive-by cleanups.
- [x] Code follows proper indentation and naming conventions.
- [x] Layering follows the [LUCA architecture](../blob/main/ARCHITECTURE.md): no logic in `DependencyClient`, no logic in `UserInterface` views, no Asset/String Catalog references from `Model`.
- [x] Implemented using only APIs that can be submitted to the App Store.
- [ ] **Localization PRs only:** Every translated string in this PR was hand-crafted by a human translator. No machine translation or LLM output was used. See [CONTRIBUTING.md → Localization](../blob/main/CONTRIBUTING.md#localization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
